### PR TITLE
Br/#119 프로필 수정 뷰 스크롤 버그 수정 및 로그아웃 기능 추가 

### DIFF
--- a/components/packingList/alone/AlonePackingListLanding.tsx
+++ b/components/packingList/alone/AlonePackingListLanding.tsx
@@ -119,7 +119,7 @@ function AlonePackingListLanding() {
 
   return (
     <>
-      <Header back title="패킹 리스트" icon="profile" />
+      <Header back title="리스트 목록" icon="profile" />
       <StyledRoot onTouchMove={() => setToggle(false)}>
         {showModal && (
           <Modal

--- a/components/packingList/together/TogetherPackingListLanding.tsx
+++ b/components/packingList/together/TogetherPackingListLanding.tsx
@@ -128,7 +128,7 @@ function TogetherPackingListLanding() {
 
   return (
     <>
-      <Header back title="패킹 리스트" icon="profile" />
+      <Header back title="리스트 목록" icon="profile" />
       <StyledRoot onTouchMove={() => setToggle(false)}>
         {showModal && (
           <Modal

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -134,7 +134,6 @@ const StyledRoot = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  /* height: calc(var(--vh, 1vh) * 100); */
   height: fit-content;
   overflow-y: visible;
 

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -44,7 +44,7 @@ function SettingProfile(props: SettingProfileProps) {
   const onClickLogout = () => {
     (async () => {
       //로그아웃
-      const { data } = await axios.post(
+      await axios.post(
         'https://kapi.kakao.com/v1/user/logout',
         {},
         {

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -6,7 +6,10 @@ import Modal from '../common/Modal';
 import Footer from '../common/Footer';
 import { ProfileList } from '../../utils/profileImages';
 import { FONT_STYLES } from '../../styles/font';
-
+import { useResetRecoilState } from 'recoil';
+import { authedUser, kakaoAccessToken } from '../../utils/recoil/atom/atom';
+import axios from 'axios';
+import { useRecoilValue } from 'recoil';
 interface ProfileData {
   _id: string;
   name: string;
@@ -26,6 +29,7 @@ function SettingProfile(props: SettingProfileProps) {
   const [showModal, setShowModal] = useState(false);
   const [isWithdrawn, setIsWithdrawn] = useState(false);
   const profileImage = ProfileList.map((e: StaticImageData, i: number) => ({ id: i + '', src: e }));
+  const accessToken = useRecoilValue(kakaoAccessToken).accessToken;
 
   const onClickLeftModalButton = async () => {
     setIsWithdrawn(true);
@@ -35,10 +39,29 @@ function SettingProfile(props: SettingProfileProps) {
     setShowModal(false);
   };
 
+  const resetUserState = useResetRecoilState(authedUser); //유저 전역변수 초기화
+
+  const onClickLogout = () => {
+    (async () => {
+      //로그아웃
+      const { data } = await axios.post(
+        'https://kapi.kakao.com/v1/user/logout',
+        {},
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+    })();
+    resetUserState();
+  };
+
   return (
     <StyledRoot>
       <StyledSettingWrapper>
-        <p>로그아웃</p>
+        <p onClick={onClickLogout}>로그아웃</p>
         <p onClick={onClickEditText}>수정</p>
 
         <StyledProfile>

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -134,14 +134,14 @@ const StyledRoot = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  height: 74.276rem;
-  overflow-y: scroll;
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
+  /* height: calc(var(--vh, 1vh) * 100); */
+  height: fit-content;
+  overflow-y: visible;
 
   & > p {
+    display: flex;
+    align-items: flex-end;
+    height: 8rem;
     color: ${packmanColors.pmDeepGrey};
   }
 `;
@@ -160,14 +160,14 @@ const StyledSettingWrapper = styled.main`
     top: -1.9rem;
     right: 0.5rem;
     color: ${packmanColors.pmDarkGrey};
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
   }
   & > p:nth-child(2) {
     position: absolute;
     top: 0.5rem;
     right: 1.5rem;
     color: ${packmanColors.pmDeepGrey};
-    font-style: ${FONT_STYLES.CAPTION2_SEMIBOLD};
+    ${FONT_STYLES.CAPTION2_SEMIBOLD};
   }
 `;
 const StyledProfile = styled.div`
@@ -189,10 +189,10 @@ const StyledProfile = styled.div`
     height: 6.5rem;
     color: ${packmanColors.pmBlack};
     & > h1 {
-      font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+      ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
     }
     & > p {
-      font-style: ${FONT_STYLES.BODY1_REGULAR};
+      ${FONT_STYLES.BODY1_REGULAR};
     }
   }
 `;
@@ -201,7 +201,7 @@ const StyledToggleWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   & > p {
-    font-style: ${FONT_STYLES.BODY1_REGULAR};
+    ${FONT_STYLES.BODY1_REGULAR};
   }
 `;
 const StyledToggle = styled.div<{ isToggled: boolean }>`
@@ -237,7 +237,7 @@ const StyledEtc = styled.div<{ gap: number; paddingTop: number; borderBottom: bo
 
   & > h1 {
     color: ${packmanColors.pmBlack};
-    font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   }
 `;
 const StyledEtcWrapper = styled.div`
@@ -246,11 +246,15 @@ const StyledEtcWrapper = styled.div`
   align-content: space-between;
   gap: 0.8rem;
   & > p {
-    font-style: ${FONT_STYLES.BODY3_REGULAR};
+    ${FONT_STYLES.BODY3_REGULAR};
     letter-spacing: 4%;
   }
 `;
 const StyledFooter = styled.div`
+  display: flex;
+  align-items: flex-end;
+  height: calc(100vh - 74rem);
+  min-height: 10.5rem;
   margin: 6.1rem 0 5rem 0;
 `;
 const StyledModalButtonWrapper = styled.div`
@@ -266,5 +270,5 @@ const StyledModalButton = styled.button<{ left?: boolean }>`
   color: ${({ left }) => (left ? packmanColors.pmDeepGrey : packmanColors.pmWhite)};
   background-color: ${({ left }) => (left ? packmanColors.pmWhite : packmanColors.pmPink)};
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
 `;

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -10,6 +10,7 @@ import { useResetRecoilState } from 'recoil';
 import { authedUser, kakaoAccessToken } from '../../utils/recoil/atom/atom';
 import axios from 'axios';
 import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
 interface ProfileData {
   _id: string;
   name: string;
@@ -30,6 +31,7 @@ function SettingProfile(props: SettingProfileProps) {
   const [isWithdrawn, setIsWithdrawn] = useState(false);
   const profileImage = ProfileList.map((e: StaticImageData, i: number) => ({ id: i + '', src: e }));
   const accessToken = useRecoilValue(kakaoAccessToken).accessToken;
+  const router = useRouter();
 
   const onClickLeftModalButton = async () => {
     setIsWithdrawn(true);
@@ -41,21 +43,25 @@ function SettingProfile(props: SettingProfileProps) {
 
   const resetUserState = useResetRecoilState(authedUser); //유저 전역변수 초기화
 
+  //로그아웃
   const onClickLogout = () => {
     (async () => {
-      //로그아웃
-      await axios.post(
-        'https://kapi.kakao.com/v1/user/logout',
-        {},
-        {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Authorization: `Bearer ${accessToken}`,
+      try {
+        await axios.post(
+          'https://kapi.kakao.com/v1/user/logout',
+          {},
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Authorization: `Bearer ${accessToken}`,
+            },
           },
-        },
-      );
+        );
+      } finally {
+        resetUserState();
+        router.push('/login');
+      }
     })();
-    resetUserState();
   };
 
   return (

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -52,7 +52,6 @@ const StyledRoot = styled.div`
   align-items: center;
   padding: 0 2rem;
   width: 100vw;
-  /* height: 100%; */
   height: calc(var(--vh, 1vh) * 100 - 8rem);
   overflow-y: auto;
   /* 브라우저별 스크롤바 숨김 설정 */

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -52,5 +52,13 @@ const StyledRoot = styled.div`
   align-items: center;
   padding: 0 2rem;
   width: 100vw;
-  height: 100vh;
+  /* height: 100%; */
+  height: calc(var(--vh, 1vh) * 100 - 8rem);
+  overflow-y: auto;
+  /* 브라우저별 스크롤바 숨김 설정 */
+  -ms-overflow-style: none; // Edge
+  scrollbar-width: none; // Firefox
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari, Opera
+  }
 `;

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -10,7 +10,6 @@ function EditProfile() {
   const [isEditing, setIsEditing] = useState(false);
   const getUserInfo = useAPI((api) => api.user.getUserInfo);
   const { data } = useQuery('getUserInfo', () => getUserInfo());
-  console.log(data);
 
   if (!data) return null;
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -9,7 +9,7 @@ import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 import axios from 'axios';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { authedUser, creatingUser, from } from '../utils/recoil/atom/atom';
+import { authedUser, creatingUser, from, kakaoAccessToken } from '../utils/recoil/atom/atom';
 import Link from 'next/link';
 
 declare global {
@@ -26,6 +26,7 @@ function Login() {
   const setCreatingUser = useSetRecoilState(creatingUser);
   const fetchKakaoLogin = useAPI((api) => api.auth.fetchKakaoLogin);
   const { mutate: kakaoLogin } = useMutation('fetchKakaoLogin', fetchKakaoLogin);
+  const setKakaoAccessToken = useSetRecoilState(kakaoAccessToken);
 
   useEffect(() => {
     if (router.isReady) {
@@ -42,6 +43,7 @@ function Login() {
               },
             },
           );
+          setKakaoAccessToken({ accessToken: data.access_token });
           kakaoLogin(
             {
               accessToken: data.access_token,

--- a/utils/recoil/atom/atom.ts
+++ b/utils/recoil/atom/atom.ts
@@ -42,4 +42,5 @@ export const kakaoAccessToken = atom<Kakao>({
   default: {
     accessToken: '',
   },
+  effects_UNSTABLE: [persistAtom],
 });

--- a/utils/recoil/atom/atom.ts
+++ b/utils/recoil/atom/atom.ts
@@ -38,7 +38,7 @@ export const from = atom<From>({
 });
 
 export const kakaoAccessToken = atom<Kakao>({
-  key: 'KAKAO',
+  key: 'kakaoAccessToken',
   default: {
     accessToken: '',
   },

--- a/utils/recoil/atom/atom.ts
+++ b/utils/recoil/atom/atom.ts
@@ -1,4 +1,4 @@
-import { User, From } from './';
+import { User, From, Kakao } from './';
 import { recoilPersist } from 'recoil-persist';
 import { atom } from 'recoil';
 
@@ -35,4 +35,11 @@ export const from = atom<From>({
     url: '',
   },
   effects_UNSTABLE: [persistAtom],
+});
+
+export const kakaoAccessToken = atom<Kakao>({
+  key: 'KAKAO',
+  default: {
+    accessToken: '',
+  },
 });

--- a/utils/recoil/atom/index.ts
+++ b/utils/recoil/atom/index.ts
@@ -10,3 +10,7 @@ export interface User {
 export interface From {
   url: string;
 }
+
+export interface Kakao {
+  accessToken: string;
+}


### PR DESCRIPTION
### Issue #119  : 프로필 수정 뷰 스크롤 버그 수정 및 로그아웃 기능 추가

### 구현 사항

- [x] 프로필 수정 뷰 스크롤 버그 수정 및 로그아웃 기능 추가

로그아웃 하려면 카카오 액세스 토큰이 필요한데, recoil로 저장하고 있는 전역 변수 `accessToken`은 우리 서비스에서 자체적으로 만들고 있는 토큰이라, 카카오 로그인 요청 시 반환되는 액세스 토큰을 recoil에 따로 저장했습니다
-----------------
### Need Review



------------
### Reference

https://user-images.githubusercontent.com/66051416/183065782-2e2d1f88-3766-4cb7-8add-3619652d9cbb.mp4


-------------
- close #119

