### PR TITLE
Br/#120 프로필 뷰 기본 이미지 선택되어 있도록 수정

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -41,10 +41,10 @@ const StyledInfo = styled.div`
       color: ${packmanColors.pmDarkGrey};
     }
     & > p:first-child {
-      font-style: ${FONT_STYLES.CAPTION2_SEMIBOLD};
+      ${FONT_STYLES.CAPTION2_SEMIBOLD};
     }
     & > p:nth-child(2) {
-      font-style: ${FONT_STYLES.CAPTION1_REGULAR};
+      ${FONT_STYLES.CAPTION1_REGULAR};
     }
   }
 `;

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -92,7 +92,7 @@ const StyledContent = styled.div<{
   justify-content: center;
   position: relative;
   background-color: ${packmanColors.pmWhite};
-  font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+  ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   color: ${packmanColors.pmBlack};
 
   & > picture {

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -69,7 +69,7 @@ const StyledModalInfo = styled.div`
   flex-direction: column;
   gap: 2.95rem;
   & > p {
-    font-style: ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
     color: #282828;
   }
 `;

--- a/components/packingList/SwipeableList.tsx
+++ b/components/packingList/SwipeableList.tsx
@@ -87,7 +87,7 @@ const StyledDeleteButton = styled.button`
   bottom: 1.507rem;
   width: calc(100vw - 4rem);
   height: 4.7rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
   background-color: ${packmanColors.pmPink};
   color: #fff;
   border: none;

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -194,11 +194,11 @@ const StyledItemInfo = styled.div`
   gap: 0.6rem;
 
   & > p:first-child {
-    font-style: ${FONT_STYLES.BODY1_REGULAR};
+    ${FONT_STYLES.BODY1_REGULAR};
     color: ${packmanColors.pmBlueGrey};
   }
   & > p:nth-child(2) {
-    font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   }
 `;
 const StyledPackInfo = styled.div`
@@ -214,7 +214,7 @@ const StyledPackInfo = styled.div`
     width: 8.3rem;
     height: 2.4rem;
     color: ${packmanColors.pmBlack};
-    font-style: ${FONT_STYLES.BODY1_REGULAR};
+    ${FONT_STYLES.BODY1_REGULAR};
     border: 0.1rem solid ${packmanColors.pmPink};
     border-radius: 1.2rem;
     text-align: center;
@@ -223,7 +223,7 @@ const StyledPackInfo = styled.div`
 const StyledPackRemainText = styled.p`
   position: absolute;
   right: 3.557rem;
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   color: ${packmanColors.pmBlack};
   & > span {
     font-weight: bold;

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -151,7 +151,8 @@ const StyledItemWrapper = styled.article<{ isDragged: boolean; isDeleting: boole
   padding: 1.41rem 0.4rem 1.9rem 1.832rem;
   border-radius: 1.5rem;
   background-color: ${packmanColors.pmBlueGrey};
-  transition: 0.4s ease-in-out;
+  transition: ease-in-out;
+  transition-duration: 0.4s;
 
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -172,6 +173,7 @@ const StyledItemWrapper = styled.article<{ isDragged: boolean; isDeleting: boole
         return css`
           animation: 0.4s ease-in-out slide;
           transform: translateX(8.388rem);
+          -webkit-transform: translate3d(0, 0, 0) translateX(8.388rem); //Safari 대응
         `;
     }
   }};

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -40,6 +40,7 @@ export default function SwipeablelistItem(props: ItemProps) {
   } = props;
 
   const { _id, departureDate, title, packTotalNum, packRemainNum } = packingList[idx];
+  const listType = router.pathname.split('/').at(-2); // togetehr | alone
 
   const onTouchStart = (e: React.TouchEvent) => {
     const startX = e.targetTouches[0].clientX;
@@ -67,7 +68,7 @@ export default function SwipeablelistItem(props: ItemProps) {
 
   const moveToPackingList = () => {
     if (!isDeleting) {
-      router.push(`/together/${packingList[idx]._id}`);
+      router.push(`/${listType}/${packingList[idx]._id}`);
     }
   };
 

--- a/components/packingList/alone/AlonePackingListLanding.tsx
+++ b/components/packingList/alone/AlonePackingListLanding.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import SwipeableList from '../SwipeableList';
 import styled from 'styled-components';
 import Image from 'next/image';

--- a/components/packingList/alone/AlonePackingListLanding.tsx
+++ b/components/packingList/alone/AlonePackingListLanding.tsx
@@ -12,10 +12,7 @@ import { useRouter } from 'next/router';
 import Modal from '../../common/Modal';
 import { packmanColors } from '../../../styles/color';
 import FloatActionButton from '../../folder/FloatActionButton';
-import {
-  DeleteAloneInventoryInput,
-  GetAloneInventoryOutput,
-} from '../../../service/inventory/alone';
+import { DeleteAloneInventoryInput } from '../../../service/inventory/alone';
 import { FONT_STYLES } from '../../../styles/font';
 import SwipeablelistItem from '../SwipeableListItem';
 interface DeleteAloneInventoryData {
@@ -57,8 +54,6 @@ function AlonePackingListLanding() {
   );
 
   if (!data) return null;
-
-  console.log(data);
 
   const { alonePackingList, folder, currentFolder } = data.data;
 
@@ -117,6 +112,14 @@ function AlonePackingListLanding() {
     }
   };
 
+  const onClickCaptionButton = () => {
+    setIsDragged(Array(alonePackingList?.length).fill(false));
+    setIsDeleting((prev) => !prev);
+    if (!isDeleting) {
+      setDeleteList([]);
+    }
+  };
+
   return (
     <>
       <Header back title="패킹 리스트" icon="profile" />
@@ -145,9 +148,7 @@ function AlonePackingListLanding() {
               width={24}
               height={24}
               toggle={toggle ? 'true' : 'false'}
-              onClick={() => {
-                setToggle(true);
-              }}
+              onClick={() => setToggle(true)}
             />
             {toggle && (
               <DropBox
@@ -175,24 +176,10 @@ function AlonePackingListLanding() {
                   </StyledCaptionText>
                 )}
                 {isDeleting && (
-                  <span
-                    onClick={() => {
-                      deleteList.length > 0 && setDeleteList([]);
-                    }}
-                  >
-                    선택 해제
-                  </span>
+                  <span onClick={() => deleteList.length > 0 && setDeleteList([])}>선택 해제</span>
                 )}
 
-                <StyledCaptionButtonWrapper
-                  onClick={() => {
-                    setIsDragged(Array(alonePackingList?.length).fill(false));
-                    setIsDeleting((prev) => !prev);
-                    if (!isDeleting) {
-                      setDeleteList([]);
-                    }
-                  }}
-                >
+                <StyledCaptionButtonWrapper onClick={onClickCaptionButton}>
                   {isDeleting ? (
                     <p onClick={() => setIsDragged(Array(alonePackingList?.length).fill(false))}>
                       취소

--- a/components/packingList/alone/AlonePackingListLanding.tsx
+++ b/components/packingList/alone/AlonePackingListLanding.tsx
@@ -263,7 +263,7 @@ const StyledFolderInfo = styled.div`
   margin-top: 0.842rem;
 
   & > h1 {
-    font-style: ${FONT_STYLES.HEADLINE2_SEMIBOLD};
+    ${FONT_STYLES.HEADLINE2_SEMIBOLD};
   }
   & > div {
     display: flex;
@@ -289,7 +289,7 @@ const StyledEmpty = styled.div`
   width: 20rem;
   text-align: center;
   color: ${packmanColors.pmGrey};
-  font-style: ${FONT_STYLES.HEADLINE1_MEDIUM};
+  ${FONT_STYLES.HEADLINE1_MEDIUM};
 `;
 const StyledCaptionWrapper = styled.div`
   position: relative;
@@ -299,7 +299,7 @@ const StyledCaptionWrapper = styled.div`
 
   & > span {
     position: absolute;
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     left: 2rem;
     bottom: 1rem;
     color: ${packmanColors.pmDarkGrey};
@@ -310,10 +310,10 @@ const StyledCaptionText = styled.p`
   justify-content: start;
   padding: 1.8rem 0 0 2.4rem;
   margin: 0;
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   color: ${packmanColors.pmDeepGrey};
   & > span {
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     color: ${packmanColors.pmPink};
   }
 `;
@@ -323,7 +323,7 @@ const StyledCaptionButtonWrapper = styled.div`
   right: 2rem;
   bottom: 0.9rem;
   & > p {
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     color: ${packmanColors.pmDarkGrey};
   }
 `;
@@ -340,5 +340,5 @@ const StyledModalButton = styled.button<{ left?: boolean }>`
   color: ${({ left }) => (left ? packmanColors.pmDeepGrey : packmanColors.pmWhite)};
   background-color: ${({ left }) => (left ? packmanColors.pmWhite : packmanColors.pmPink)};
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
 `;

--- a/components/packingList/together/TogetherPackingListLanding.tsx
+++ b/components/packingList/together/TogetherPackingListLanding.tsx
@@ -269,7 +269,7 @@ const StyledFolderInfo = styled.div`
   margin-top: 0.842rem;
 
   & > h1 {
-    font-style: ${FONT_STYLES.HEADLINE2_SEMIBOLD};
+    ${FONT_STYLES.HEADLINE2_SEMIBOLD};
   }
   & > div {
     display: flex;
@@ -295,7 +295,7 @@ const StyledEmpty = styled.div`
   width: 20rem;
   text-align: center;
   color: ${packmanColors.pmGrey};
-  font-style: ${FONT_STYLES.HEADLINE1_MEDIUM};
+  ${FONT_STYLES.HEADLINE1_MEDIUM};
 `;
 const StyledCaptionWrapper = styled.div`
   position: relative;
@@ -307,7 +307,7 @@ const StyledCaptionWrapper = styled.div`
     position: absolute;
     left: 2.6rem;
     bottom: 0.8rem;
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     color: ${packmanColors.pmDeepGrey};
   }
 `;
@@ -316,10 +316,10 @@ const StyledCaptionText = styled.p`
   justify-content: start;
   padding: 1.8rem 0 0 2.4rem;
   margin: 0;
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   color: ${packmanColors.pmDeepGrey};
   & > span {
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     color: ${packmanColors.pmPink};
   }
 `;
@@ -329,7 +329,7 @@ const StyledCaptionButtonWrapper = styled.div`
   right: 2rem;
   bottom: 0.8rem;
   & > p {
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     color: ${packmanColors.pmDeepGrey};
   }
 `;
@@ -346,5 +346,5 @@ const StyledModalButton = styled.button<{ left?: boolean }>`
   color: ${({ left }) => (left ? packmanColors.pmDeepGrey : packmanColors.pmWhite)};
   background-color: ${({ left }) => (left ? packmanColors.pmWhite : packmanColors.pmPink)};
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
 `;

--- a/components/packingList/together/TogetherPackingListLanding.tsx
+++ b/components/packingList/together/TogetherPackingListLanding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import SwipeableList from '../SwipeableList';
 import styled from 'styled-components';
 import Image from 'next/image';
@@ -12,10 +12,7 @@ import { useRouter } from 'next/router';
 import Modal from '../../common/Modal';
 import { packmanColors } from '../../../styles/color';
 import FloatActionButton from '../../folder/FloatActionButton';
-import {
-  DeleteTogetherInventoryInput,
-  GetTogetherInventoryOutput,
-} from '../../../service/inventory/together';
+import { DeleteTogetherInventoryInput } from '../../../service/inventory/together';
 import { FONT_STYLES } from '../../../styles/font';
 import SwipeablelistItem from '../SwipeableListItem';
 

--- a/components/profile/CreateProfile.tsx
+++ b/components/profile/CreateProfile.tsx
@@ -28,9 +28,9 @@ const StyledCommentWrapper = styled.h1`
     color: #000;
     word-break: break-all;
     word-wrap: break-word;
-    font-style: ${FONT_STYLES.DISPLAY1_LIGHT};
+    ${FONT_STYLES.DISPLAY1_LIGHT};
   }
   & b {
-    font-style: ${FONT_STYLES.DISPLAY2_SEMIBOLD};
+    ${FONT_STYLES.DISPLAY2_SEMIBOLD};
   }
 `;

--- a/components/profile/EditingProfile.tsx
+++ b/components/profile/EditingProfile.tsx
@@ -31,15 +31,4 @@ const StyledCommentWrapper = styled.h1`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  & > h1 {
-    line-height: 2.9rem;
-    font-weight: 300;
-    font-size: 2.4rem;
-    color: #000;
-    word-break: break-all;
-    word-wrap: break-word;
-  }
-  & b {
-    font-weight: 500;
-  }
 `;

--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -38,10 +38,9 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
   const [nickname, setNickname] = useState('');
   const [profile, setProfile] = useState('');
   const [index, setIndex] = useState(''); //중앙 120px 이미지 다룰 인덱스
-  // const [user, setUser] = useGlobalState<User>('User');
   const setUser = useSetRecoilState(authedUser);
   const user = useRecoilValue(creatingUser);
-  console.log('user', user);
+
   //프로필 생성
   const addUserProfile = useAPI((api) => api.user.addUserProfile);
   const { mutate: addUserProfileMutate } = useMutation(
@@ -101,7 +100,6 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
       setIndex(id);
     }
   };
-  console.log(user);
   return (
     <StyledRoot>
       <div style={{ position: 'relative', width: '12rem', height: '12rem' }}>
@@ -198,7 +196,7 @@ const StyledInputWrapper = styled.div`
 const StyledInput = styled.input`
   width: 12rem;
   text-align: center;
-  font-style: ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
+  ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
   color: ${packmanColors.pmBlack};
   border: none;
   border-bottom: 1px solid ${packmanColors.pmDeepGrey};
@@ -216,7 +214,7 @@ const StyledText = styled.div<{ nickname: boolean }>`
   opacity: ${({ nickname }) => nickname && '0'};
   padding-top: 0.77rem;
   color: ${packmanColors.pmDeepGrey};
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
 `;
 
 const StyledSelectProfileWrapper = styled.div`
@@ -247,7 +245,7 @@ const StyledButton = styled.button<{ isActivate: boolean }>`
   border: none;
   border-radius: 0.8rem;
   padding: 1.2rem 6.4rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
   color: ${packmanColors.pmWhite};
   background-color: ${({ isActivate }) =>
     isActivate ? packmanColors.pmPink : packmanColors.pmGrey};

--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -102,35 +102,41 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
     }
   };
 
+  // 프로필 수정
+  const editUserProfile = () => {
+    if (finishEditing) {
+      updateUserProfileMutate({
+        name: nickname,
+        profileImageId: profile,
+      });
+      finishEditing();
+    }
+  };
+
+  // 회원가입
+  const createUserAccount = () => {
+    addUserProfileMutate(
+      {
+        email: user.email,
+        name: nickname,
+        profileImageId: profile,
+      },
+      {
+        onSuccess: ({ data }) => {
+          setUser(data);
+          router.push('/folder');
+        },
+      },
+    );
+  };
+
   const onClickGoToPackingButton = () => {
-    isEditing
-      ? (async () => {
-          if (finishEditing) {
-            updateUserProfileMutate({
-              name: nickname,
-              profileImageId: profile,
-            });
-            finishEditing();
-          }
-        })()
-      : addUserProfileMutate(
-          {
-            email: user.email,
-            name: nickname,
-            profileImageId: profile,
-          },
-          {
-            onSuccess: ({ data }) => {
-              setUser(data);
-              router.push('/folder');
-            },
-          },
-        );
+    isEditing ? editUserProfile() : createUserAccount();
   };
 
   return (
     <StyledRoot>
-      <div style={{ position: 'relative', width: '12rem', height: '12rem' }}>
+      <div style={{ position: 'relative', width: '120', height: '120' }}>
         <Image src={profileImage[+index].src} alt="profile-image" layout="fill" priority />
       </div>
       <StyledInputWrapper>

--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -33,9 +33,9 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
   const router = useRouter();
   const { isEditing, oldNickname, oldProfileImageId, finishEditing } = props;
   const profileImage = ProfileList.map((e: StaticImageData, i: number) => ({ id: i + '', src: e }));
-  const [nickname, setNickname] = useState('');
-  const [profile, setProfile] = useState(oldProfileImageId ? '' : '0');
-  const [index, setIndex] = useState(''); //중앙 120px 이미지 다룰 인덱스
+  const [nickname, setNickname] = useState(oldNickname ? oldNickname : '');
+  const [profile, setProfile] = useState(oldProfileImageId ? oldProfileImageId : '0');
+  const [index, setIndex] = useState(oldProfileImageId ? oldProfileImageId : ''); //중앙 120px 이미지 다룰 인덱스
   const setUser = useSetRecoilState(authedUser);
   const user = useRecoilValue(creatingUser);
 
@@ -128,20 +128,10 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
         );
   };
 
-  useEffect(() => {
-    if (oldProfileImageId) {
-      setProfile(oldProfileImageId);
-      setIndex(oldProfileImageId);
-    }
-    if (oldNickname) {
-      setNickname(oldNickname);
-    }
-  }, []);
-
   return (
     <StyledRoot>
       <div style={{ position: 'relative', width: '12rem', height: '12rem' }}>
-        <Image src={profileImage[+index].src} alt="profile-image" layout="fill" />
+        <Image src={profileImage[+index].src} alt="profile-image" layout="fill" priority />
       </div>
       <StyledInputWrapper>
         <StyledInput
@@ -168,6 +158,7 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
               width={80}
               height={80}
               selected={profile === id}
+              priority
             />
           </StyledImageWrapper>
         ))}

--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -36,7 +36,7 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
   const { isEditing, oldNickname, oldProfileImageId, finishEditing } = props;
   const profileImage = ProfileList.map((e: StaticImageData, i: number) => ({ id: i + '', src: e }));
   const [nickname, setNickname] = useState('');
-  const [profile, setProfile] = useState('');
+  const [profile, setProfile] = useState(oldProfileImageId ? '' : '0');
   const [index, setIndex] = useState(''); //중앙 120px 이미지 다룰 인덱스
   const setUser = useSetRecoilState(authedUser);
   const user = useRecoilValue(creatingUser);

--- a/components/profile/SettingProfile.tsx
+++ b/components/profile/SettingProfile.tsx
@@ -137,14 +137,14 @@ const StyledSettingWrapper = styled.main`
     top: -1.9rem;
     right: 0.5rem;
     color: ${packmanColors.pmDarkGrey};
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
   }
   & > p:nth-child(2) {
     position: absolute;
     top: 0.5rem;
     right: 1.5rem;
     color: ${packmanColors.pmDeepGrey};
-    font-style: ${FONT_STYLES.CAPTION2_SEMIBOLD};
+    ${FONT_STYLES.CAPTION2_SEMIBOLD};
   }
 `;
 const StyledProfile = styled.div`
@@ -166,10 +166,10 @@ const StyledProfile = styled.div`
     height: 6.5rem;
     color: ${packmanColors.pmBlack};
     & > h1 {
-      font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+      ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
     }
     & > p {
-      font-style: ${FONT_STYLES.BODY1_REGULAR};
+      ${FONT_STYLES.BODY1_REGULAR};
     }
   }
 `;
@@ -178,7 +178,7 @@ const StyledToggleWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   & > p {
-    font-style: ${FONT_STYLES.BODY1_REGULAR};
+    ${FONT_STYLES.BODY1_REGULAR};
   }
 `;
 const StyledToggle = styled.div<{ isToggled: boolean }>`
@@ -214,7 +214,7 @@ const StyledEtc = styled.div<{ gap: number; paddingTop: number; borderBottom: bo
 
   & > h1 {
     color: ${packmanColors.pmBlack};
-    font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   }
 `;
 const StyledEtcWrapper = styled.div`
@@ -223,7 +223,7 @@ const StyledEtcWrapper = styled.div`
   align-content: space-between;
   gap: 0.8rem;
   & > p {
-    font-style: ${FONT_STYLES.BODY3_REGULAR};
+    ${FONT_STYLES.BODY3_REGULAR};
     letter-spacing: 4%;
   }
 `;
@@ -243,5 +243,5 @@ const StyledModalButton = styled.button<{ left?: boolean }>`
   color: ${({ left }) => (left ? packmanColors.pmDeepGrey : packmanColors.pmWhite)};
   background-color: ${({ left }) => (left ? packmanColors.pmWhite : packmanColors.pmPink)};
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
 `;

--- a/components/selectTemplate/Template.tsx
+++ b/components/selectTemplate/Template.tsx
@@ -129,11 +129,11 @@ const StyledTemplateWrapper = styled.div`
   width: 100%;
   gap: 1rem;
   & > h1 {
-    font-style: ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
     color: ${packmanColors.pmBlack};
   }
   & > p {
-    font-style: ${FONT_STYLES.CAPTION1_REGULAR};
+    ${FONT_STYLES.CAPTION1_REGULAR};
     color: ${packmanColors.pmDeepGrey};
   }
 `;

--- a/components/selectTemplate/TemplateItem.tsx
+++ b/components/selectTemplate/TemplateItem.tsx
@@ -69,7 +69,7 @@ const StyledRoot = styled.div<{ isListEmpty: boolean; isSelected: boolean }>`
   height: 3.4rem;
   padding: 0.7rem 1.1rem;
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
 
   ${({ isSelected }) =>
     isSelected

--- a/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
+++ b/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
@@ -71,6 +71,7 @@ function AloneSelectTemplateLanding() {
               alt="template-image"
               width={375}
               height={211}
+              priority
             />
           )}
         </picture>

--- a/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
+++ b/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
@@ -88,7 +88,7 @@ function AloneSelectTemplateLanding() {
           basicTemplate={basicTemplate}
           myTemplate={myTemplate}
           activate={(isSelected: string) =>
-            isSelected === '' ? deactivateConfirmButton : activateConfirmButton
+            isSelected === '' ? deactivateConfirmButton() : activateConfirmButton()
           }
           changeTemplateImage={(templateId: string) => changeTemplateImage(templateId)}
           changeUserOwnTemplateImage={(templateId: string) =>

--- a/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
+++ b/components/selectTemplate/alone/AloneSelectTemplateLanding.tsx
@@ -52,8 +52,16 @@ function AloneSelectTemplateLanding() {
         setRandomImageList((prev) => prev.sort(() => Math.random() - 0.5));
       }
     });
-    // setTemplateImageIndex(Math.floor(Math.random() * 4).toString());
   };
+
+  const onClickConfirmButton = () => {
+    isBasicTemplate
+      ? router.push(`/preview?id=${templateId}&type=basic&categoryName=alone`)
+      : router.push(`/preview?id=${templateId}&type=myTemplate&categoryName=alone`);
+  };
+
+  const activateConfirmButton = () => setActivateButton(true);
+  const deactivateConfirmButton = () => setActivateButton(false);
 
   return (
     <StyledRoot>
@@ -79,13 +87,9 @@ function AloneSelectTemplateLanding() {
           isAloned={true}
           basicTemplate={basicTemplate}
           myTemplate={myTemplate}
-          activate={(isSelected: string) => {
-            if (isSelected === '') {
-              setActivateButton(false);
-            } else {
-              setActivateButton(true);
-            }
-          }}
+          activate={(isSelected: string) =>
+            isSelected === '' ? deactivateConfirmButton : activateConfirmButton
+          }
           changeTemplateImage={(templateId: string) => changeTemplateImage(templateId)}
           changeUserOwnTemplateImage={(templateId: string) =>
             changeUserOwnTemplateImage(templateId)
@@ -98,9 +102,7 @@ function AloneSelectTemplateLanding() {
         <StyleButton
           isTemplate={false}
           isActivated={true}
-          onClick={() => {
-            router.push(`/list-intro?id=''&categoryName=alone`);
-          }}
+          onClick={() => router.push(`/list-intro?id=''&categoryName=alone`)}
         >
           건너뛰기
         </StyleButton>
@@ -108,13 +110,7 @@ function AloneSelectTemplateLanding() {
           isTemplate={true}
           disabled={!activateButton}
           isActivated={activateButton}
-          onClick={() => {
-            if (isBasicTemplate) {
-              router.push(`/preview?id=${templateId}&type=basic&categoryName=alone`);
-            } else {
-              router.push(`/preview?id=${templateId}&type=myTemplate&categoryName=alone`);
-            }
-          }}
+          onClick={onClickConfirmButton}
         >
           확인
         </StyleButton>

--- a/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
+++ b/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
@@ -51,8 +51,16 @@ function TogetherSelectTemplateLanding() {
         setRandomImageList((prev) => prev.sort(() => Math.random() - 0.5));
       }
     });
-    // setTemplateImageIndex(Math.floor(Math.random() * 4).toString());
   };
+
+  const onClickConfirmButton = () => {
+    isBasicTemplate
+      ? router.push(`/preview?id=${templateId}&type=basic&categoryName=together`)
+      : router.push(`/preview?id=${templateId}&type=myTemplate&categoryName=together`);
+  };
+
+  const activateConfirmButton = () => setActivateButton(true);
+  const deactivateConfirmButton = () => setActivateButton(false);
 
   return (
     <StyledRoot>
@@ -78,13 +86,9 @@ function TogetherSelectTemplateLanding() {
           isAloned={false}
           basicTemplate={basicTemplate}
           myTemplate={myTemplate}
-          activate={(isSelected: string) => {
-            if (isSelected === '') {
-              setActivateButton(false);
-            } else {
-              setActivateButton(true);
-            }
-          }}
+          activate={(isSelected: string) =>
+            isSelected === '' ? deactivateConfirmButton : activateConfirmButton
+          }
           changeTemplateImage={(templateId: string) => changeTemplateImage(templateId)}
           changeUserOwnTemplateImage={changeUserOwnTemplateImage}
           checkIsTemplate={(isTemplate: boolean) => setIsBasicTemplate(isTemplate)}
@@ -95,9 +99,7 @@ function TogetherSelectTemplateLanding() {
         <StyleButton
           isTemplate={false}
           isActivated={true}
-          onClick={() => {
-            router.push(`/list-intro?id=''&categoryName=together`);
-          }}
+          onClick={() => router.push(`/list-intro?id=''&categoryName=together`)}
         >
           건너뛰기
         </StyleButton>
@@ -105,13 +107,7 @@ function TogetherSelectTemplateLanding() {
           isTemplate={true}
           disabled={!activateButton}
           isActivated={activateButton}
-          onClick={() => {
-            if (isBasicTemplate) {
-              router.push(`/preview?id=${templateId}&type=basic&categoryName=together`);
-            } else {
-              router.push(`/preview?id=${templateId}&type=myTemplate&categoryName=together`);
-            }
-          }}
+          onClick={onClickConfirmButton}
         >
           확인
         </StyleButton>

--- a/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
+++ b/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
@@ -70,6 +70,7 @@ function TogetherSelectTemplateLanding() {
               alt="template-image"
               width={375}
               height={211}
+              priority
             />
           )}
         </picture>

--- a/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
+++ b/components/selectTemplate/together/TogetherSelectTemplateLanding.tsx
@@ -87,7 +87,7 @@ function TogetherSelectTemplateLanding() {
           basicTemplate={basicTemplate}
           myTemplate={myTemplate}
           activate={(isSelected: string) =>
-            isSelected === '' ? deactivateConfirmButton : activateConfirmButton
+            isSelected === '' ? deactivateConfirmButton() : activateConfirmButton()
           }
           changeTemplateImage={(templateId: string) => changeTemplateImage(templateId)}
           changeUserOwnTemplateImage={changeUserOwnTemplateImage}

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -10,6 +10,7 @@ import { FONT_STYLES } from '../styles/font';
 
 function EditProfile() {
   const [isEditing, setIsEditing] = useState(false);
+  const finishEditingProfileHandler = () => setIsEditing(false);
   const getUserInfo = useAPI((api) => api.user.getUserInfo);
   const { data } = useQuery('getUserInfo', () => getUserInfo());
 
@@ -31,9 +32,7 @@ function EditProfile() {
               }
               oldNickname={name}
               oldProfileImageId={profileImageId}
-              finishEditing={() => {
-                setIsEditing(false);
-              }}
+              finishEditing={finishEditingProfileHandler}
             />
           </>
         ) : (

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -5,6 +5,8 @@ import useAPI from '../utils/hooks/useAPI';
 import { useQuery } from 'react-query';
 import EditingProfile from '../components/profile/EditingProfile';
 import SettingProfile from '../components/profile/SettingProfile';
+import { packmanColors } from '../styles/color';
+import { FONT_STYLES } from '../styles/font';
 
 function EditProfile() {
   const [isEditing, setIsEditing] = useState(false);
@@ -23,9 +25,9 @@ function EditProfile() {
           <>
             <EditingProfile
               comment={
-                <h1>
+                <StyledTitle>
                   <b>프로필 수정</b>을 완료해주세요!
-                </h1>
+                </StyledTitle>
               }
               oldNickname={name}
               oldProfileImageId={profileImageId}
@@ -53,4 +55,14 @@ const StyledRoot = styled.div`
   padding: 0 2rem;
   width: 100vw;
   height: 100vh;
+`;
+const StyledTitle = styled.h1`
+  ${FONT_STYLES.DISPLAY1_LIGHT};
+  color: ${packmanColors.pmBlack};
+  word-break: break-all;
+  word-wrap: break-word;
+
+  & > b {
+    ${FONT_STYLES.DISPLAY2_SEMIBOLD};
+  }
 `;

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -10,7 +10,6 @@ function EditProfile() {
   const [isEditing, setIsEditing] = useState(false);
   const getUserInfo = useAPI((api) => api.user.getUserInfo);
   const { data } = useQuery('getUserInfo', () => getUserInfo());
-  console.log(data);
 
   if (!data) return null;
 


### PR DESCRIPTION
### Issue #120  : 프로필 뷰 기본 이미지 선택되어 있도록 수정

### 구현 사항

- [x] 프로필 뷰 기본 이미지 선택되어 있도록 수정
- [x] 사파리 `리스트 목록 뷰` 에서 휴지통 클릭 시 transition 오류 해결하고 싶은 코드 추가 > 배포 후 확인 필요
- [x] 리스트목록뷰 아이템 클릭 시 together/[id]로만 가던 것 해결 
`const listType = router.pathname.split('/').at(-2); // togetehr | alone`  -> 이렇게 해놨어요
-----------------
### Need Review



------------
### Reference

1. 프로필 뷰 default profile image 설정

https://user-images.githubusercontent.com/66051416/183067464-bf8ce38a-071a-4821-ac98-5a417e4390a8.mp4


2. 리스트 목록 뷰 휴지통 클릭 시 웹에서 보이는 애니메이션


https://user-images.githubusercontent.com/66051416/183067270-143caddc-f4f8-4511-951e-ba271dc50910.mp4




-------------
- close #120

