### PR TITLE
chore/#153 : 리스트 목록 뷰 아이템 클릭 시 라우팅 방법 변경

### DIFF
--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -24,6 +24,7 @@ interface ItemProps {
   checkDeleteList: (id: string) => void;
   onClickDeleteButton: (idx: number) => void;
   packingList: PackingList[];
+  moveToPackingList: () => void;
 }
 
 export default function SwipeablelistItem(props: ItemProps) {
@@ -37,10 +38,10 @@ export default function SwipeablelistItem(props: ItemProps) {
     checkDeleteList,
     onClickDeleteButton,
     packingList,
+    moveToPackingList,
   } = props;
 
   const { _id, departureDate, title, packTotalNum, packRemainNum } = packingList[idx];
-  const listType = router.pathname.split('/').at(-2); // togetehr | alone
 
   const onTouchStart = (e: React.TouchEvent) => {
     const startX = e.targetTouches[0].clientX;
@@ -64,12 +65,6 @@ export default function SwipeablelistItem(props: ItemProps) {
     }
     document.addEventListener('touchmove', Move);
     document.addEventListener('touchend', End);
-  };
-
-  const moveToPackingList = () => {
-    if (!isDeleting) {
-      router.push(`/${listType}/${packingList[idx]._id}`);
-    }
   };
 
   return (

--- a/components/packingList/alone/AlonePackingListLanding.tsx
+++ b/components/packingList/alone/AlonePackingListLanding.tsx
@@ -121,6 +121,12 @@ function AlonePackingListLanding() {
     }
   };
 
+  const moveToPackingList = (id: string) => {
+    if (!isDeleting) {
+      router.push(`/alone/${id}`);
+    }
+  };
+
   return (
     <>
       <Header back title="리스트 목록" icon="profile" />
@@ -217,6 +223,7 @@ function AlonePackingListLanding() {
                       openModal();
                     }}
                     packingList={alonePackingList}
+                    moveToPackingList={() => moveToPackingList(item._id)}
                   />
                 ))}
               />

--- a/components/packingList/together/TogetherPackingListLanding.tsx
+++ b/components/packingList/together/TogetherPackingListLanding.tsx
@@ -122,6 +122,12 @@ function TogetherPackingListLanding() {
     }
   };
 
+  const moveToPackingList = (id: string) => {
+    if (!isDeleting) {
+      router.push(`/together/${id}`);
+    }
+  };
+
   return (
     <>
       <Header back title="리스트 목록" icon="profile" />
@@ -227,6 +233,7 @@ function TogetherPackingListLanding() {
                     openModal();
                   }}
                   packingList={togetherPackingList}
+                  moveToPackingList={() => moveToPackingList(item._id)}
                 />
               ))}
             />


### PR DESCRIPTION
### Issue #153  : 리스트 목록 뷰 아이템 클릭 시 라우팅 방법 변경

### 구현 사항

- [x] 리스트 목록 뷰 아이템 클릭 시 router.pathname에서 split으로 추출하지 말고 그냥 props로 onClick메소드 넘겨주는 방식으로 변경
-----------------
### Need Review



------------
### Reference
-------------
- close #153

