### PR TITLE
chore/#182 : 프로필 등록 api 수정 및 로딩중일 때 header 숨기기 위한 boolean props 추가

### DIFF
--- a/components/common/Layout.tsx
+++ b/components/common/Layout.tsx
@@ -12,13 +12,14 @@ interface LayoutProps {
   title?: string;
   icon?: Icon;
   option?: ReactNode;
+  hasHeader?: boolean;
 }
 
 function Layout(props: LayoutProps) {
-  const { children, back, title, icon, option, padding } = props;
+  const { children, back, title, icon, option, padding, hasHeader } = props;
   return (
     <StyledRoot>
-      <Header back={back} title={title} icon={icon} />
+      {hasHeader && <Header back={back} title={title} icon={icon} />}
       {option}
       <StyledMain hasOption={option !== undefined} padding={padding ? true : false}>
         {children}

--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -4,16 +4,15 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { packmanColors } from '../../styles/color';
 import useAPI from '../../utils/hooks/useAPI';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { ProfileList } from '../../utils/profileImages';
 import { FONT_STYLES } from '../../styles/font';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { authedUser, creatingUser, kakao } from '../../utils/recoil/atom/atom';
-import axios from 'axios';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { authedUser, creatingUser } from '../../utils/recoil/atom/atom';
 
 interface AddUserProfileData {
   email: string; // 회원가입한 유저의 이메일
-  name: string; //회원가입한 유저의 카카오 프로필 네임
+  name: string;
   nickname: string; // 회원가입한 유저의 닉네임
   profileImage: string; // 회원가입한 유저의 프로필 이미지
 }
@@ -30,14 +29,6 @@ interface SelectProfileSectionProps {
   finishEditing?: () => void;
 }
 
-interface KakaoProfileInfo {
-  kakao_account: {
-    profile: {
-      nickname: string;
-    };
-  };
-}
-
 function SelectProfileSection(props: SelectProfileSectionProps) {
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -46,9 +37,7 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
   const [nickname, setNickname] = useState(oldNickname ? oldNickname : '');
   const [profile, setProfile] = useState(oldProfileImageId ? oldProfileImageId : '0');
   const [index, setIndex] = useState(oldProfileImageId ? oldProfileImageId : ''); //중앙 120px 이미지 다룰 인덱스
-  const setUser = useSetRecoilState(authedUser);
-  const user = useRecoilValue(creatingUser);
-  const { accessToken } = useRecoilValue(kakao);
+  const [user, setUser] = useRecoilState(authedUser);
 
   //프로필 생성
   const addUserProfile = useAPI((api) => api.user.addUserProfile);
@@ -124,29 +113,13 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
     }
   };
 
-  // 카카오톡 사용자 프로필 닉네임 조회
-  const getKakaoProfileInfo = async () => {
-    const { data }: { data: KakaoProfileInfo } = await axios.post(
-      `https://kapi.kakao.com/v2/user/me`,
-      {},
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-    return data;
-  };
-
   // 회원가입
   const createUserAccount = async () => {
-    const data = await getKakaoProfileInfo();
-
     addUserProfileMutate(
       {
         email: user.email,
-        name: data.kakao_account.profile.nickname,
         nickname,
+        name: user.name,
         profileImage: profile,
       },
       {

--- a/utils/AsyncBoundary.tsx
+++ b/utils/AsyncBoundary.tsx
@@ -56,8 +56,8 @@ export function AsyncBoundary({ children, loadingFallback }: AsyncBoundaryProps)
       <Suspense
         fallback={
           loadingFallback ?? (
-            <Layout>
-              <Lottie animationData={lottie} />
+            <Layout hasHeader={false}>
+              <Lottie animationData={lottie} style={{ height: '100%' }} />
             </Layout>
           )
         }


### PR DESCRIPTION
### Issue #182 : 프로필 등록 api 수정 및 로딩중일 때 header 숨기기 위한 boolean props 추가

### 구현 사항

- [x] 프로필 등록 api 수정 > 로그인 시 서버에서 주는 name을 creatingUser에서 갖다 썼었는데, authedUser에서 가져오는 걸로 변경 > persist 때문에 바꿈
- [x] 로딩중일 때 header 숨기기 위한 boolean props 추가
-----------------
### Need Review



------------
### Reference
-------------
- close #182

