### PR TITLE
feat/#180 : token refresh 기능 추가

### DIFF
--- a/service/auth/createAPI.tsx
+++ b/service/auth/createAPI.tsx
@@ -1,12 +1,10 @@
-import { AxiosInstance } from 'axios';
-import { Refresh, KakaoLoginInput, KakaoLoginOutput } from './index';
+import { RefreshInput, RefreshOutput, KakaoLoginInput, KakaoLoginOutput } from './index';
 import { GoogleLoginInput, GoogleLoginOutput } from '.';
 import { fetchGoogleLogin, fetchKakaoLogin, fetchRefresh } from '../../utils/axios/auth';
-import withAuth from '../../utils/axios/withAuth';
 import { Config } from '../../utils/axios/axios';
 
 export interface AuthAPI {
-  refresh: (accessToken: string, refreshToken: string) => Promise<Refresh>;
+  refresh: (tokens: RefreshInput) => Promise<RefreshOutput>;
   fetchGoogleLogin: (payload: GoogleLoginInput) => Promise<GoogleLoginOutput>;
   fetchKakaoLogin: (payload: KakaoLoginInput) => Promise<KakaoLoginOutput>;
 }
@@ -15,8 +13,7 @@ const createAuthAPI = ({ axiosBasic, axiosWithAuth: request }: Config): AuthAPI 
   return {
     fetchGoogleLogin: (payload: GoogleLoginInput) => fetchGoogleLogin(request, payload),
     fetchKakaoLogin: (payload: KakaoLoginInput) => fetchKakaoLogin(request, payload),
-    refresh: (accessToken, refreshToken: string) =>
-      fetchRefresh(request, accessToken, refreshToken),
+    refresh: (tokens) => fetchRefresh(axiosBasic, tokens),
   };
 };
 

--- a/service/auth/index.ts
+++ b/service/auth/index.ts
@@ -36,7 +36,11 @@ export interface KakaoLoginOutput {
   };
 }
 
-export interface Refresh {
+export interface RefreshInput {
+  accessToken: string;
+  refreshToken: string;
+}
+export interface RefreshOutput {
   status: number;
   success: boolean;
   message: string;

--- a/utils/axios/auth/index.ts
+++ b/utils/axios/auth/index.ts
@@ -1,4 +1,9 @@
-import { KakaoLoginInput, KakaoLoginOutput } from './../../../service/auth/index';
+import {
+  KakaoLoginInput,
+  KakaoLoginOutput,
+  RefreshInput,
+  RefreshOutput,
+} from './../../../service/auth/index';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { GoogleLoginInput, GoogleLoginOutput } from '../../../service/auth/index';
 
@@ -20,12 +25,11 @@ export const fetchKakaoLogin = async (
 
 export const fetchRefresh = async (
   request: AxiosInstance,
-  accessToken: string,
-  refreshToken: string,
-) => {
+  { accessToken, refreshToken }: RefreshInput,
+): Promise<RefreshOutput> => {
   const { data } = await request(`/auth/token`, {
+    baseURL: process.env.NEXT_PUBLIC_END,
     headers: {
-      'Content-Type': 'application/json',
       Authorization: accessToken,
       Refresh: refreshToken,
     },

--- a/utils/axios/withAuth.tsx
+++ b/utils/axios/withAuth.tsx
@@ -1,20 +1,17 @@
 import { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { useRefresh } from '../hooks/queries/auth/auth';
-import useAPI from '../hooks/useAPI';
-import { AuthUser } from '../recoil/atom';
 import { authUserAtom } from '../recoil/atom/atom';
 
 function withAuth(axiosWithAuth: AxiosInstance) {
-  // const router = useRouter();
-  const { accessToken, refreshToken } = useRecoilValue(authUserAtom);
-  const [refresh] = useRefresh({ accessToken, refreshToken });
+  const tokens = useRecoilValue(authUserAtom);
+  const refresh = useRefresh(tokens);
 
   const requestIntercept = axiosWithAuth.interceptors.request.use(
     (config: AxiosRequestConfig) => {
       if (config.headers && !config.headers['Authorization']) {
-        // config.headers['Authorization'] = `${accessToken}`;
+        config.headers['Authorization'] = `${tokens.accessToken}`;
+
         return config;
       }
 
@@ -30,13 +27,19 @@ function withAuth(axiosWithAuth: AxiosInstance) {
       return config;
     },
     async (error) => {
+      const config = error.config;
+
       if (error.response.status === 401) {
-        // console.log('401!');
-        // const prev = error.config;
-        // const { data } = await refresh();
-        // console.log('re', data);
-        // router.replace('/login');
+        const tokens = await refresh();
+
+        if (tokens) {
+          config.headers['Authorization'] = `${tokens.accessToken}`;
+
+          return axiosWithAuth(config);
+        }
       }
+
+      return Promise.reject(error);
     },
   );
   return axiosWithAuth;

--- a/utils/hooks/queries/auth/auth.ts
+++ b/utils/hooks/queries/auth/auth.ts
@@ -17,7 +17,7 @@ export const useRefresh = (tokens: RefreshInput) => {
       const { data } = await client.fetchQuery<RefreshOutput>('refresh', () =>
         fetchRefresh(tokens),
       );
-      setUser((prev) => ({ ...prev, ...tokens }));
+      setUser((prev) => ({ ...prev, ...data }));
 
       return data;
     } catch (error) {

--- a/utils/hooks/queries/auth/auth.ts
+++ b/utils/hooks/queries/auth/auth.ts
@@ -1,22 +1,34 @@
-import { useQuery, useQueryClient } from 'react-query';
-import { Refresh } from '../../../../service/auth';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/router';
+import { useQueryClient } from 'react-query';
+import { useSetRecoilState } from 'recoil';
+import { RefreshInput, RefreshOutput } from '../../../../service/auth';
+import { authUserAtom } from '../../../recoil/atom/atom';
 import useAPI from '../../useAPI';
 
-export const useRefresh = ({
-  accessToken,
-  refreshToken,
-}: {
-  accessToken: string;
-  refreshToken: string;
-}) => {
+export const useRefresh = (tokens: RefreshInput) => {
+  const router = useRouter();
   const client = useQueryClient();
+  const setUser = useSetRecoilState(authUserAtom);
   const fetchRefresh = useAPI((api) => api.auth.refresh);
 
-  const { data } = useQuery('refresh', () => fetchRefresh(accessToken, refreshToken), {
-    enabled: false,
-  });
+  const refresh = async () => {
+    try {
+      const { data } = await client.fetchQuery<RefreshOutput>('refresh', () =>
+        fetchRefresh(tokens),
+      );
+      setUser((prev) => ({ ...prev, ...tokens }));
 
-  const refresh = () => client.fetchQuery<Refresh>('refresh');
+      return data;
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        alert('세션이 만료되었습니다. 다시 로그인 해주세요.');
+        router.replace('/login');
+      } else {
+        throw new Error();
+      }
+    }
+  };
 
-  return [refresh];
+  return refresh;
 };


### PR DESCRIPTION
### Issue #180

### 구현 사항

- [x] ver.1 1주차 - token 재발급 api 추가
-----------------
### Need Review

- refresh 로직을 더욱 독립적으로 구분 하는것이 좋을지 고민입니다
- 세션 만료시 recoil-persist에 저장된 로그인 정보를 초기화 시키는 것이 좋을지 고민입니다

------------------

### Preview 

![화면 기록 2022-08-26 오전 4 59 17](https://user-images.githubusercontent.com/79056677/186757743-526f377c-744b-425b-a565-e2f4e3fc885c.gif)


------------
### Reference
-------------
- close #[WiP]

