### PR TITLE
Br/#211 AsyncBoundary 리팩토링

### DIFF
--- a/components/alone/AloneLanding.tsx
+++ b/components/alone/AloneLanding.tsx
@@ -17,6 +17,7 @@ import PackingListBottomModal from '../common/PackingListBottomModal';
 import { useRouter } from 'next/router';
 import ModalForAddToTemplate from '../common/ModalForAddToTemplate';
 import ModalForShare from '../common/ModalForShare';
+import Loading from '../common/Loading';
 
 interface FocusInfo {
   type: 'category' | 'item';
@@ -114,7 +115,7 @@ function AloneLanding() {
     'deleteAlonePackingListItem',
     deleteAlonePackingListItem,
   );
-  if (!data) return null;
+  if (!data) return <Loading />;
   const { data: list } = data;
   const addTemplateModalOpenHandler = () => setAddTemplateModalOpen(true);
   const addTemplateModalCloseHandler = () => setAddTemplateModalOpen(false);

--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Layout from './Layout';
+import Lottie from 'lottie-react';
+import { lottie } from '../../public/assets';
+
+function Loading() {
+  return (
+    <Layout noHeader>
+      <Lottie animationData={lottie} style={{ height: '100%' }} />
+    </Layout>
+  );
+}
+
+export default Loading;

--- a/components/together/TogetherLanding.tsx
+++ b/components/together/TogetherLanding.tsx
@@ -24,6 +24,7 @@ import PackingListBottomModal from '../common/PackingListBottomModal';
 import { useRecoilValue } from 'recoil';
 import { authUserAtom } from '../../utils/recoil/atom/atom';
 import ModalForAddToTemplate from '../common/ModalForAddToTemplate';
+import Loading from '../common/Loading';
 
 interface FocusInfo {
   type: 'category' | 'item';
@@ -149,7 +150,7 @@ function TogetherLanding() {
     setInvitationModalOpen(true);
   }, []);
 
-  if (!packingListData) return null;
+  if (!packingListData) return <Loading />;
   const { data: info } = packingListData;
   const packingRole = [info.togetherPackingList, info.myPackingList];
   const modeHandler = (idx: number) => setActiveMode(idx);

--- a/utils/AsyncBoundary.tsx
+++ b/utils/AsyncBoundary.tsx
@@ -1,10 +1,8 @@
 import { PropsWithChildren, ReactNode, Suspense, useState } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { useQueryErrorResetBoundary } from 'react-query';
-import Lottie from 'lottie-react';
-import { lottie } from '../public/assets';
 import Error from '../components/common/Error';
-import Layout from '../components/common/Layout';
+import Loading from '../components/common/Loading';
 
 interface AsyncBoundaryProps {
   loadingFallback?: ReactNode;
@@ -55,17 +53,7 @@ export function AsyncBoundary({
       }}
       onReset={reset}
     >
-      <Suspense
-        fallback={
-          loadingFallback ?? (
-            <Layout noHeader>
-              <Lottie animationData={lottie} style={{ height: '100%' }} />
-            </Layout>
-          )
-        }
-      >
-        {children}
-      </Suspense>
+      <Suspense fallback={loadingFallback ?? <Loading />}>{children}</Suspense>
     </ErrorBoundary>
   );
 }

--- a/utils/AsyncBoundary.tsx
+++ b/utils/AsyncBoundary.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Suspense, useState } from 'react';
+import { PropsWithChildren, ReactNode, Suspense, useState } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { useQueryErrorResetBoundary } from 'react-query';
 import Lottie from 'lottie-react';
@@ -8,7 +8,6 @@ import Layout from '../components/common/Layout';
 
 interface AsyncBoundaryProps {
   loadingFallback?: ReactNode;
-  children: ReactNode;
 }
 
 const isExpectedError = <Error extends unknown>(res: Error): res is Error => {
@@ -41,7 +40,10 @@ const errorFallback = ({ resetErrorBoundary }: FallbackProps) => {
   );
 };
 
-export function AsyncBoundary({ children, loadingFallback }: AsyncBoundaryProps) {
+export function AsyncBoundary({
+  children,
+  loadingFallback,
+}: PropsWithChildren<AsyncBoundaryProps>) {
   const { reset } = useQueryErrorResetBoundary();
   return (
     <ErrorBoundary


### PR DESCRIPTION
### Issue #211 

### 구현 사항

- [x] AsyncBoundary type 수정
- [x] Loading 로티 컴포넌트로 분리
- [x] 패킹리스트에 별도로 Loading 컴포넌트 추가

-----------------

### Message

Dependent Queries 방식
```javascript
const {data} = useQuery('query',fn,{
 enabled : !!id
})
```

을 사용하는 경우 요청이 suspense에 걸리지 않는 것 같아요
따라서 따로 로딩 컴포넌트를 추가해주었습니다

-----------------
### Need Review



------------
### Reference
-------------
- close #211

