### PR TITLE
Br/#237 : 로그인 로직 수정

### DIFF
--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -125,7 +125,8 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
       },
       {
         onSuccess: ({ data }) => {
-          setUser((prev) => ({ ...prev, ...data }));
+          /**@todo 스키마 통합 후 data로 변경 */
+          setUser({ ...creatingUser, ...data });
           router.push('/folder');
         },
       },

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -53,7 +53,7 @@ function Login() {
             {
               onSuccess: ({ data }) => {
                 if (data.isAlreadyUser) {
-                  setUser((prev) => ({ ...prev, ...data }));
+                  setUser(data as typeof user);
                 } else {
                   setCreatingUser(data);
                   router.replace('/profile');

--- a/service/user/index.ts
+++ b/service/user/index.ts
@@ -50,8 +50,8 @@ export interface AddUserProfileOutput {
     id: string; // 생성된 유저 id
     nickname: string; // 생성된 유저 닉네임
     email: string; // 생성된 유저 email
-    profileImageId: string; // 생성된 유저 이미지 id
+    profileImage: string; // 생성된 유저 이미지 id
     accessToken: string; // 팩맨에서 사용하는 accessToken
-    isAlreadyUser: boolean; // 이미 존재하는 유저 확인
+    refreshToken: string;
   };
 }

--- a/utils/axios/folder/index.ts
+++ b/utils/axios/folder/index.ts
@@ -8,7 +8,6 @@ import {
   UpdateFolderNameOutput,
 } from './../../../service/folder/index';
 import { AxiosInstance } from 'axios';
-import { request } from 'http';
 
 export const fetchFolders = async (request: AxiosInstance): Promise<GetFoldersOutput> => {
   const { data } = await request(`/folder`);

--- a/utils/hooks/queries/auth/auth.ts
+++ b/utils/hooks/queries/auth/auth.ts
@@ -22,15 +22,18 @@ export const useRefresh = (tokens: RefreshInput) => {
 
       return data;
     } catch (error) {
-      if (error instanceof AxiosError)
-        alert('g' + JSON.stringify(error.response?.status) + JSON.stringify(error.response));
-      if (error instanceof AxiosError && error.response?.status === 401) {
-        resetUser();
-        // alert('세션이 만료되었습니다. 다시 로그인 해주세요.');
-        alert('re' + JSON.stringify(error) + '//' + localStorage.getItem('recoil-persist'));
-        router.replace('/login');
-      } else {
-        throw new Error();
+      if (error instanceof AxiosError) {
+        switch (error.response?.status) {
+          case 400:
+          case 401: {
+            resetUser();
+            alert('세션이 만료되었습니다. 다시 로그인 해주세요.');
+            router.replace('/login');
+            return;
+          }
+          default:
+            throw new Error();
+        }
       }
     }
   };


### PR DESCRIPTION
### Issue #237 

### 구현 사항

- [x] 로직 변경시 기존 토큰은 400 발생 > 유저 초기화 후 로그인 페이지로 라우팅
- [x] 유저 등록시 스프레드 연산자를 삭제하여 항상 스키마로 로컬 스토리지에 저장되도록 수정
-----------------
### Need Review



------------
### Reference
-------------
- close #237 

