### PR TITLE
Br/#269 기타 수정 및 리스트 목록 뷰 사용성 개선

### DIFF
--- a/components/packingList/PackingListLanding.tsx
+++ b/components/packingList/PackingListLanding.tsx
@@ -165,6 +165,12 @@ function PackingListLanding() {
     setIsDeleting(false);
   };
 
+  // 개별 삭제
+  const onClickDeleteListItem = (idx: number) => {
+    setSelectedIndex(idx);
+    openModal();
+  };
+
   return (
     <Layout back title="리스트 목록" icon="profile">
       <StyledRoot
@@ -237,10 +243,7 @@ function PackingListLanding() {
                   isDeleting={isDeleting}
                   deleteList={deleteList}
                   checkDeleteList={(id: string) => checkDeleteList(id)}
-                  onClickDeleteButton={() => {
-                    setSelectedIndex(idx);
-                    openModal();
-                  }}
+                  onClickDeleteButton={() => onClickDeleteListItem(idx)}
                   packingList={togetherPackingList ?? alonePackingList}
                   moveToPackingList={() => moveToPackingList(item.id)}
                 />

--- a/components/packingList/SwipeableList.tsx
+++ b/components/packingList/SwipeableList.tsx
@@ -19,8 +19,6 @@ const StyledRoot = styled.div`
   background-color: #fff;
   overflow-y: auto;
 
-  touch-action: pan-x;
-
   /* 브라우저별 스크롤바 숨김 설정 */
   -ms-overflow-style: none; // Edge
   scrollbar-width: none; // Firefox

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -55,10 +55,10 @@ export default function SwipeablelistItem(props: ItemProps) {
 
       let tmpArr = Array(packingList?.length).fill(false);
 
-      if (startX - endX > 50) {
+      if (startX - endX > 20) {
         tmpArr = tmpArr.map((_, index) => (idx === index ? true : false));
         handleIsDragged(tmpArr);
-      } else if (endX - startX > 50) {
+      } else if (endX - startX > 20) {
         if (isDragged[idx]) {
           handleIsDragged(tmpArr);
         }

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -41,6 +41,8 @@ export default function SwipeablelistItem(props: ItemProps) {
   const { id, departureDate, title, packTotalNum, packRemainNum } = packingList[idx];
 
   const onTouchStart = (e: React.TouchEvent) => {
+    document.body.style.overflow = 'hidden';
+
     const startX = e.targetTouches[0].clientX;
     const startY = e.targetTouches[0].clientY;
     let endX = e.targetTouches[0].clientX;
@@ -69,6 +71,8 @@ export default function SwipeablelistItem(props: ItemProps) {
     }
     document.addEventListener('touchmove', Move);
     document.addEventListener('touchend', End);
+
+    document.body.style.overflow = 'auto';
   };
 
   return (

--- a/components/profile/ProfileLanding.tsx
+++ b/components/profile/ProfileLanding.tsx
@@ -1,24 +1,39 @@
+import { useEffect } from 'react';
 import CreateProfile from './CreateProfile';
 import styled from 'styled-components';
 import Layout from '../common/Layout';
+import { useRecoilValue } from 'recoil';
+import { authUserAtom } from '../../utils/recoil/atom/atom';
+import { useRouter } from 'next/router';
 
 function ProfileLanding() {
+  const router = useRouter();
+  const { isAlreadyUser } = useRecoilValue(authUserAtom);
+
+  useEffect(() => {
+    if (isAlreadyUser) {
+      router.replace('/folder');
+    }
+  }, []);
+
   return (
-    <Layout padding>
-      <StyledRoot>
-        <CreateProfile
-          comment={
-            <div>
-              <h1>환영합니다 :^)</h1>
-              <h1>
-                <b>팩맨</b>에서 사용하실 <b>프로필</b>을
-              </h1>
-              <h1>완성해주세요.</h1>
-            </div>
-          }
-        />
-      </StyledRoot>
-    </Layout>
+    !isAlreadyUser && (
+      <Layout padding>
+        <StyledRoot>
+          <CreateProfile
+            comment={
+              <div>
+                <h1>환영합니다 :^)</h1>
+                <h1>
+                  <b>팩맨</b>에서 사용하실 <b>프로필</b>을
+                </h1>
+                <h1>완성해주세요.</h1>
+              </div>
+            }
+          />
+        </StyledRoot>
+      </Layout>
+    )
   );
 }
 

--- a/components/profile/ProfileLanding.tsx
+++ b/components/profile/ProfileLanding.tsx
@@ -17,23 +17,25 @@ function ProfileLanding() {
   }, []);
 
   return (
-    !isAlreadyUser && (
-      <Layout padding>
-        <StyledRoot>
-          <CreateProfile
-            comment={
-              <div>
-                <h1>환영합니다 :^)</h1>
-                <h1>
-                  <b>팩맨</b>에서 사용하실 <b>프로필</b>을
-                </h1>
-                <h1>완성해주세요.</h1>
-              </div>
-            }
-          />
-        </StyledRoot>
-      </Layout>
-    )
+    <>
+      {!isAlreadyUser && (
+        <Layout padding>
+          <StyledRoot>
+            <CreateProfile
+              comment={
+                <div>
+                  <h1>환영합니다 :^)</h1>
+                  <h1>
+                    <b>팩맨</b>에서 사용하실 <b>프로필</b>을
+                  </h1>
+                  <h1>완성해주세요.</h1>
+                </div>
+              }
+            />
+          </StyledRoot>
+        </Layout>
+      )}
+    </>
   );
 }
 

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -21,7 +21,7 @@ function EditProfile() {
   const { nickname, profileImage } = data.data;
 
   return (
-    <Layout {...layoutProps}>
+    <Layout {...layoutProps} padding>
       <StyledRoot isEditing={isEditing}>
         {isEditing ? (
           <EditingProfile
@@ -48,11 +48,9 @@ const StyledRoot = styled.div<{ isEditing: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100vw;
-  height: ${({ isEditing }) =>
-    isEditing ? 'calc(var(--vh, 1vh) * 100 )' : 'calc(var(--vh, 1vh) * 100 - 8rem)'};
+  height: ${({ isEditing }) => (isEditing ? '100% ' : '100% ')};
+  margin-top: ${({ isEditing }) => isEditing && '6rem'};
   overflow-y: auto;
-  padding: 0 2rem;
 
   /* 브라우저별 스크롤바 숨김 설정 */
   -ms-overflow-style: none; // Edge

--- a/pages/edit-profile.tsx
+++ b/pages/edit-profile.tsx
@@ -48,7 +48,7 @@ const StyledRoot = styled.div<{ isEditing: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: ${({ isEditing }) => (isEditing ? '100% ' : '100% ')};
+  height: 100%;
   margin-top: ${({ isEditing }) => isEditing && '6rem'};
   overflow-y: auto;
 


### PR DESCRIPTION
### Issue #269  : 기타 수정 및 리스트 목록 뷰 사용성 개선

### 구현 사항

- [x] 리스트 목록 뷰 스와이프 좀만 건드려도 스와이프 되도록 수정
- [x] 프로필 수정 뷰 > 변경된 Layout에 맞게 padding 조절 및 상단에 margin 추가
- [x] 회원가입 뷰 isAlreadyUser인 경우 folder로 라우팅시킴
- [x] 리스트 목록 뷰 > touch start할 때 body에 overflow:hidden주고 end일때 해당 속성 해제함 > 리스트 아이템 열 때 상하 스크롤 되는 이슈 해결을 위함
-----------------
### Need Review

구현사항 4번에 리스트 목록 뷰에서 아이템 스와이프 할 때 스크롤 방지를 위해 DOM에 접근했는데, 뭔가.. 별로 좋은 방식같지는 않네요... 이 부분에 대해서 어떻게 생각하시는지 궁금해요

------------
### Reference
-------------
- close #269

