### PR TITLE
Br/#358 : GA id 수정, GoogleTagManager 컨벤션에 맞춰서 수정

### DIFF
--- a/components/GoogleTagManager.tsx
+++ b/components/GoogleTagManager.tsx
@@ -3,16 +3,19 @@ import React from 'react';
 
 export type GoogleTagManagerId = `GTM-${string}`;
 
-interface Props {
+interface GoogleTagManagerProps {
   googleTagManagerId: GoogleTagManagerId;
 }
 
-const GoogleTagManager: React.FC<Props> = ({ googleTagManagerId }) => (
-  <Script
-    id="gtm"
-    strategy="afterInteractive"
-    dangerouslySetInnerHTML={{
-      __html: `
+function GoogleTagManager(props: GoogleTagManagerProps) {
+  const { googleTagManagerId } = props;
+
+  return (
+    <Script
+      id="gtm"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
       (function(w,d,s,l,i)
             {
               w[l] = w[l] || [];
@@ -23,8 +26,9 @@ const GoogleTagManager: React.FC<Props> = ({ googleTagManagerId }) => (
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','${googleTagManagerId}');
       `,
-    }}
-  />
-);
+      }}
+    />
+  );
+}
 
 export default GoogleTagManager;


### PR DESCRIPTION
### Issue #358 : GA id 수정, GoogleTagManager 컨벤션에 맞춰서 수정
### 구현 사항

- [x] GA id 수정, GoogleTagManager 컨벤션에 맞춰서 수정 -> GTM-${id} 라서 id 만 env파일에 적어주면 되는데 GTM- 까지 넣어버려서 400 에러가 났었습니다.
-----------------
### Need Review



------------
### Reference
-------------
- close #358

