### PR TITLE
fix/#358 : GTM 컴포넌트에 props 넘기는 대신 직접 상수 받아오도록 변경

### DIFF
--- a/components/GoogleTagManager.tsx
+++ b/components/GoogleTagManager.tsx
@@ -1,15 +1,8 @@
 import Script from 'next/script';
 import React from 'react';
+import { googleTagManagerId } from '../utils/constant/index';
 
-export type GoogleTagManagerId = `GTM-${string}`;
-
-interface GoogleTagManagerProps {
-  googleTagManagerId: GoogleTagManagerId;
-}
-
-function GoogleTagManager(props: GoogleTagManagerProps) {
-  const { googleTagManagerId } = props;
-
+function GoogleTagManager() {
   return (
     <Script
       id="gtm"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,8 +10,7 @@ import InstallGuide from '../components/common/InstallGuide';
 import HeadMeta from '../components/HeadMeta';
 import { AsyncBoundary } from '../utils/AsyncBoundary';
 import React from 'react';
-import GoogleTagManager, { GoogleTagManagerId } from '../components/GoogleTagManager';
-import { googleTagManagerId } from '../utils/constant/index';
+import GoogleTagManager from '../components/GoogleTagManager';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [show, setShow] = useState(false);
@@ -43,7 +42,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <GoogleTagManager googleTagManagerId={googleTagManagerId as GoogleTagManagerId} />
+      <GoogleTagManager />
       <HeadMeta title={title} description={description} />
       <CssBaseline />
       <GlobalStyle />


### PR DESCRIPTION
### Issue #358 : GTM 컴포넌트에 props 넘기는 대신 직접 상수 받아오도록 변경

### 구현 사항

- [x]  GTM 컴포넌트에 props 넘기는 대신 직접 상수 받아오도록 변경
-----------------
### Need Review



------------
### Reference
-------------
- close #358

