### PR TITLE
Fix/#373 폴더 에러 수정

### DIFF
--- a/components/folder/FolderBox.tsx
+++ b/components/folder/FolderBox.tsx
@@ -142,7 +142,7 @@ export const StyledInfo = styled.div`
 export const StyledKebab = styled.div`
   display: flex;
   justify-content: flex-end;
-  padding: 0.5rem 0rem 0 0;
+  padding: 0.7rem 0 0 0;
   z-index: 10;
   cursor: pointer;
 
@@ -156,7 +156,7 @@ export const StyledText = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding: 0 0 2rem 1.6rem;
+  margin: 0 1.5rem 2rem 1.5rem;
   height: 100%;
 `;
 
@@ -171,6 +171,7 @@ export const StyledInput = styled.input<{ isNew: boolean }>`
   -webkit-text-fill-color: ${({ isNew }) =>
     isNew ? `${packmanColors.pmDeepGrey}` : `${packmanColors.pmBlack}`};
   opacity: 1;
+  width: 100%;
 
   &:focus {
     outline: none;

--- a/components/folder/FolderBox.tsx
+++ b/components/folder/FolderBox.tsx
@@ -16,7 +16,7 @@ function FolderBox(props: FolderBoxProps & AddNewFolderType) {
   const {
     id = '',
     name = '',
-    listNum = '',
+    listNum = '0',
     editableFolderId = '',
     categoryName = '',
     isNew = false,

--- a/components/folder/FolderBox.tsx
+++ b/components/folder/FolderBox.tsx
@@ -75,6 +75,12 @@ function FolderBox(props: FolderBoxProps & AddNewFolderType) {
     }
   };
 
+  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      onBlur();
+    }
+  };
+
   useEffect(() => {
     if (isEditing) {
       ref.current && ref.current?.focus();
@@ -109,6 +115,7 @@ function FolderBox(props: FolderBoxProps & AddNewFolderType) {
             placeholder={isNew ? '폴더 이름 입력' : ''}
             onChange={onChange}
             onBlur={onBlur}
+            onKeyPress={onKeyPress}
             disabled={!isEditing}
             isNew={isNew}
             maxLength={8}

--- a/components/folder/FolderLanding.tsx
+++ b/components/folder/FolderLanding.tsx
@@ -179,6 +179,7 @@ function FolderLanding() {
 
   const handleOnBlurInAdd = () => {
     setAddNewFolder(false);
+    setNewFolderData({ name: '', isAloned: false });
 
     if (newFolderData.name) {
       addFolderMutate(newFolderData, {


### PR DESCRIPTION
### Issue #373 : 폴더 에러 수정

### 구현 사항

- [x] 생성시 연속 폴더 생성하고, 화면 밖 누르면 같은 이름 폴더 자동으로 생겨버림 → 그냥 생성 아예 안되게 
- [x] PC에서 엔터 누르면 폴더 생성 안되고 밖을 누르거나 해야함 → 컴에서 안되는 오류 수정 필요 
- [x] 폴더 생성시, 폴더 이름 적는 칸 아래 ‘개의 리스트’로 나옴 → ‘0개의 리스트’로 수정 필요 
- [x] 폴더 생성시 인풋창 좌우 여백 동일하게 맞춰주세요~
-----------------
### Need Review



------------
### Reference
-------------
- close #373

