### PR TITLE
함께 패킹 링크 공유시, 패킹리스트명 노출

### DIFF
--- a/components/HeadMeta.tsx
+++ b/components/HeadMeta.tsx
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import { NextSeo } from 'next-seo';
 
 interface HeadMetaProps {
   title?: string;
@@ -7,31 +7,30 @@ interface HeadMetaProps {
 }
 
 function HeadMeta(props: HeadMetaProps) {
-  const { title, description, url } = props;
+  const {
+    title = '팩맨 Packman - 내 손안 짐챙김 도우미',
+    description = '내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!',
+    url = 'https:/www.packman.kr',
+  } = props;
 
   return (
-    <Head>
-      <title>{title || '팩맨 Packman - 내 손안 짐챙김 도우미'}</title>
-      <meta
-        name="description"
-        content={description || '내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!'}
-      />
-      <meta property="og:locale" content="ko" />
-      <meta property="og:site_name" content="Packman" />
-      <meta property="og:type" content="website" />
-      <meta
-        property="og:title"
-        content={title || '팩맨 Packman - 내 손안 짐챙김 도우미'}
-        key="og:title"
-      />
-      <meta
-        property="og:description"
-        content={description || '내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!'}
-        key="og:description"
-      />
-      <meta property="og:image" content="/assets/pwa/apple-splash-1136-640.jpg" />
-      <meta property="og:url" content={url || 'https://www.packman.kr'} key="og:url" />
-    </Head>
+    <NextSeo
+      title={title}
+      description="내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!"
+      openGraph={{
+        url,
+        title,
+        description,
+        siteName: 'Packman',
+        images: [
+          {
+            url: '/assets/pwa/apple-splash-1136-640.jpg',
+            alt: 'Packman Og Image',
+            type: 'image/jpg',
+          },
+        ],
+      }}
+    />
   );
 }
 export default HeadMeta;

--- a/components/alone/AloneLanding.tsx
+++ b/components/alone/AloneLanding.tsx
@@ -19,6 +19,7 @@ import useHide from '../../utils/hooks/useHide';
 import { GetAlonePackingListDetailOutput } from '../../service/packingList/alone';
 import { AxiosError } from 'axios';
 import useDynamic from '../../utils/hooks/useDynamic';
+import HeadMeta from '../HeadMeta';
 
 interface FocusInfo {
   type: 'category' | 'item';
@@ -397,119 +398,128 @@ function AloneLanding() {
   };
 
   return (
-    <Layout
-      back
-      title="패킹리스트"
-      folderId={list.folderId}
-      option={
-        <CheckListHeader
-          listId={list.id}
-          departureDate={header.departureDate}
-          title={header.title}
-          updateRemainingInfo={updateRemainingInfo}
-        />
-      }
-    >
-      <StyledAloneLanding>
-        <CheckListSubHeader categoryHandler={creatingCategoryHandler} />
-        <StyledBody onScroll={scrollEvent} ref={sectionArr.current[0]}>
-          {list.category.map(({ id: categoryId, name, pack }) => (
-            <PackagesWithCategory
-              key={categoryId}
-              packages={
-                <>
-                  {pack.map(({ id: packId, name, isChecked }) => (
-                    <PackingItem
-                      key={packId}
-                      listId={list.id}
-                      categoryId={categoryId}
-                      packId={packId}
-                      name={name}
-                      isChecked={isChecked}
-                      modalHandler={() =>
-                        bottomModalOpenHandler({
-                          ...initialFocus,
-                          type: 'item',
-                          packId,
-                          categoryId,
-                          title: name,
-                        })
-                      }
-                      isEditing={currentEditing === packId}
-                      updateItem={updateItem}
-                    />
-                  ))}
-                </>
-              }
-              isCreating={currentCreating === categoryId}
-              createHandler={() => creatingHandler(categoryId)}
-              creating={
-                <PackingItem
-                  listId={list.id}
+    <>
+      <HeadMeta
+        title={header.title}
+        description={`[${header.title}] 패킹리스트가 공유되었어요!`}
+        url={window.location.href}
+      />
+      <Layout
+        back
+        title="패킹리스트"
+        folderId={list.folderId}
+        option={
+          <CheckListHeader
+            listId={list.id}
+            departureDate={header.departureDate}
+            title={header.title}
+            updateRemainingInfo={updateRemainingInfo}
+          />
+        }
+      >
+        <StyledAloneLanding>
+          <CheckListSubHeader categoryHandler={creatingCategoryHandler} />
+          <StyledBody onScroll={scrollEvent} ref={sectionArr.current[0]}>
+            {list.category.map(({ id: categoryId, name, pack }) => (
+              <PackagesWithCategory
+                key={categoryId}
+                packages={
+                  <>
+                    {pack.map(({ id: packId, name, isChecked }) => (
+                      <PackingItem
+                        key={packId}
+                        listId={list.id}
+                        categoryId={categoryId}
+                        packId={packId}
+                        name={name}
+                        isChecked={isChecked}
+                        modalHandler={() =>
+                          bottomModalOpenHandler({
+                            ...initialFocus,
+                            type: 'item',
+                            packId,
+                            categoryId,
+                            title: name,
+                          })
+                        }
+                        isEditing={currentEditing === packId}
+                        updateItem={updateItem}
+                      />
+                    ))}
+                  </>
+                }
+                isCreating={currentCreating === categoryId}
+                createHandler={() => creatingHandler(categoryId)}
+                creating={
+                  <PackingItem
+                    listId={list.id}
+                    categoryId={categoryId}
+                    packId={'creating'}
+                    name={''}
+                    isChecked={false}
+                    isEditing={true}
+                    updateItem={updateItem}
+                  />
+                }
+              >
+                <PackingCategory
                   categoryId={categoryId}
-                  packId={'creating'}
-                  name={''}
-                  isChecked={false}
-                  isEditing={true}
-                  updateItem={updateItem}
+                  listId={list.id}
+                  name={name}
+                  updateCategory={updateCategory}
+                  modalHandler={() =>
+                    bottomModalOpenHandler({
+                      ...initialFocus,
+                      type: 'category',
+                      categoryId,
+                      title: name,
+                    })
+                  }
+                  isEditing={currentEditing === categoryId}
                 />
+              </PackagesWithCategory>
+            ))}
+            {currentCreatingCategory === list.id && (
+              <PackagesWithCategory>
+                <PackingCategory
+                  categoryId={'creating'}
+                  listId={list.id}
+                  name={''}
+                  updateCategory={updateCategory}
+                  isEditing={true}
+                />
+              </PackagesWithCategory>
+            )}
+          </StyledBody>
+          <FunctionSection>
+            <AddTemplateButton
+              onClick={() =>
+                updateRemainingInfo({ listId: list.id, isSaved: list.isSaved }, 'save')
               }
             >
-              <PackingCategory
-                categoryId={categoryId}
-                listId={list.id}
-                name={name}
-                updateCategory={updateCategory}
-                modalHandler={() =>
-                  bottomModalOpenHandler({
-                    ...initialFocus,
-                    type: 'category',
-                    categoryId,
-                    title: name,
-                  })
-                }
-                isEditing={currentEditing === categoryId}
-              />
-            </PackagesWithCategory>
-          ))}
-          {currentCreatingCategory === list.id && (
-            <PackagesWithCategory>
-              <PackingCategory
-                categoryId={'creating'}
-                listId={list.id}
-                name={''}
-                updateCategory={updateCategory}
-                isEditing={true}
-              />
-            </PackagesWithCategory>
-          )}
-        </StyledBody>
-        <FunctionSection>
-          <AddTemplateButton
-            onClick={() => updateRemainingInfo({ listId: list.id, isSaved: list.isSaved }, 'save')}
-          >
-            {list.isSaved ? '나만의 템플릿 업데이트' : '나만의 템플릿으로 추가'}
-          </AddTemplateButton>
-          <SharePackingListButton icon onClick={shareTemplateModalOpenHandler}>
-            패킹 리스트 공유
-          </SharePackingListButton>
-        </FunctionSection>
-      </StyledAloneLanding>
-      {bottomModalOpen && (
-        <PackingListBottomModal
-          onEdit={onEdit}
-          onDelete={onDelete}
-          closeModal={bottomModalCloseHandler}
-          content={currentFocus.title}
-        />
-      )}
-      {addTemplateModalOpen && (
-        <AddToTemplateModal title={list.title} onClick={addTemplateModalCloseHandler} />
-      )}
-      {shareTemplateModalOpen && (
-        <ModalForShare onClick={shareTemplateModalCloseHandler} inviteCode={list.inviteCode} />
-      )}
-    </Layout>
+              {list.isSaved ? '나만의 템플릿 업데이트' : '나만의 템플릿으로 추가'}
+            </AddTemplateButton>
+            <SharePackingListButton icon onClick={shareTemplateModalOpenHandler}>
+              패킹 리스트 공유
+            </SharePackingListButton>
+          </FunctionSection>
+        </StyledAloneLanding>
+        {bottomModalOpen && (
+          <PackingListBottomModal
+            onEdit={onEdit}
+            onDelete={onDelete}
+            closeModal={bottomModalCloseHandler}
+            content={currentFocus.title}
+          />
+        )}
+        {addTemplateModalOpen && (
+          <AddToTemplateModal title={list.title} onClick={addTemplateModalCloseHandler} />
+        )}
+        {shareTemplateModalOpen && (
+          <ModalForShare onClick={shareTemplateModalCloseHandler} inviteCode={list.inviteCode} />
+        )}
+      </Layout>
+    </>
   );
 }
 

--- a/components/together/TogetherLanding.tsx
+++ b/components/together/TogetherLanding.tsx
@@ -26,6 +26,7 @@ import useHide from '../../utils/hooks/useHide';
 import { GetTogetherPackingListBodyOutput } from '../../service/packingList/together';
 import { AxiosError } from 'axios';
 import useDynamic from '../../utils/hooks/useDynamic';
+import HeadMeta from '../HeadMeta';
 
 interface FocusInfo {
   type: 'category' | 'item';
@@ -617,162 +618,169 @@ function TogetherLanding() {
   };
 
   return (
-    <Layout
-      back
-      title="패킹리스트"
-      icon="member"
-      listId={info.id}
-      folderId={info.folderId}
-      option={
-        <CheckListHeader
-          together
-          listId={info.id}
-          departureDate={header.departureDate}
-          title={header.title}
-          activeMode={activeMode}
-          updateRemainingInfo={updateRemainingInfo}
-        />
-      }
-    >
-      <StyledTogetherLanding>
-        <Swiper
-          modules={[Pagination, Virtual]}
-          style={{ height: '100%' }}
-          onSlideChange={(s) => setActiveMode(s.activeIndex)}
-          virtual
-        >
-          <CheckListSubHeader
+    <>
+      <HeadMeta
+        title={header.title}
+        description={`[${header.title}] 패킹리스트가 공유되었어요!`}
+        url={window.location.href}
+      />
+      <Layout
+        back
+        title="패킹리스트"
+        icon="member"
+        listId={info.id}
+        folderId={info.folderId}
+        option={
+          <CheckListHeader
             together
-            slot="container-start"
+            listId={info.id}
+            departureDate={header.departureDate}
+            title={header.title}
             activeMode={activeMode}
-            modeHandler={modeHandler}
-            categoryHandler={creatingCategoryHandler}
+            updateRemainingInfo={updateRemainingInfo}
           />
-          {packingRole.map((list, i) => {
-            return (
-              <SwiperSlide key={list.id} virtualIndex={i}>
-                <StyledBody onScroll={scrollEvent} ref={sectionArr.current[i]}>
-                  {list.category.map(({ id: categoryId, name, pack }) => (
-                    <PackagesWithCategory
-                      key={categoryId}
-                      packages={
-                        <>
-                          {pack.map(({ id: packId, name, isChecked, packer }) => (
-                            <PackingItem
-                              key={packId}
-                              listId={list.id}
-                              categoryId={categoryId}
-                              packId={packId}
-                              name={name}
-                              isChecked={isChecked}
-                              mode={activeMode}
-                              modalHandler={() =>
-                                bottomModalOpenHandler({
-                                  ...initialFocus,
-                                  type: 'item',
-                                  categoryId,
-                                  packId,
-                                  title: name,
-                                })
-                              }
-                              isEditing={currentEditing === packId}
-                              updateItem={updateItem}
-                              assignee={
-                                <Packer
-                                  packer={packer}
-                                  modalHandler={() => packerModalOpenHandler(packId)}
-                                />
-                              }
-                            />
-                          ))}
-                        </>
-                      }
-                      isCreating={currentCreating === categoryId}
-                      createHandler={() => creatingItemHandler(categoryId)}
-                      creating={
-                        <PackingItem
-                          listId={list.id}
-                          categoryId={categoryId}
-                          packId={'creating'}
-                          name={''}
-                          isChecked={false}
-                          isEditing={true}
-                          updateItem={updateItem}
-                          mode={activeMode}
-                        />
-                      }
-                    >
-                      <PackingCategory
-                        categoryId={categoryId}
-                        listId={list.id}
-                        name={name}
-                        updateCategory={updateCategory}
-                        modalHandler={() =>
-                          bottomModalOpenHandler({
-                            ...initialFocus,
-                            type: 'category',
-                            categoryId,
-                            title: name,
-                          })
-                        }
-                        isEditing={currentEditing === categoryId}
-                      />
-                    </PackagesWithCategory>
-                  ))}
-                  {currentCreatingCategory === list.id && (
-                    <PackagesWithCategory>
-                      <PackingCategory
-                        categoryId={'creating'}
-                        listId={list.id}
-                        name={''}
-                        updateCategory={updateCategory}
-                        isEditing={true}
-                      />
-                    </PackagesWithCategory>
-                  )}
-                  <StyledScrollBlock />
-                </StyledBody>
-              </SwiperSlide>
-            );
-          })}
-        </Swiper>
-        <FunctionSection>
-          <AddTemplateButton
-            onClick={() =>
-              updateRemainingInfo(
-                { listId: info.id, isSaved: info.togetherPackingList.isSaved },
-                'save',
-              )
-            }
+        }
+      >
+        <StyledTogetherLanding>
+          <Swiper
+            modules={[Pagination, Virtual]}
+            style={{ height: '100%' }}
+            onSlideChange={(s) => setActiveMode(s.activeIndex)}
+            virtual
           >
-            {info.togetherPackingList.isSaved ? '템플릿 업데이트' : '나만의 템플릿으로 추가'}
-          </AddTemplateButton>
-        </FunctionSection>
-      </StyledTogetherLanding>
+            <CheckListSubHeader
+              together
+              slot="container-start"
+              activeMode={activeMode}
+              modeHandler={modeHandler}
+              categoryHandler={creatingCategoryHandler}
+            />
+            {packingRole.map((list, i) => {
+              return (
+                <SwiperSlide key={list.id} virtualIndex={i}>
+                  <StyledBody onScroll={scrollEvent} ref={sectionArr.current[i]}>
+                    {list.category.map(({ id: categoryId, name, pack }) => (
+                      <PackagesWithCategory
+                        key={categoryId}
+                        packages={
+                          <>
+                            {pack.map(({ id: packId, name, isChecked, packer }) => (
+                              <PackingItem
+                                key={packId}
+                                listId={list.id}
+                                categoryId={categoryId}
+                                packId={packId}
+                                name={name}
+                                isChecked={isChecked}
+                                mode={activeMode}
+                                modalHandler={() =>
+                                  bottomModalOpenHandler({
+                                    ...initialFocus,
+                                    type: 'item',
+                                    categoryId,
+                                    packId,
+                                    title: name,
+                                  })
+                                }
+                                isEditing={currentEditing === packId}
+                                updateItem={updateItem}
+                                assignee={
+                                  <Packer
+                                    packer={packer}
+                                    modalHandler={() => packerModalOpenHandler(packId)}
+                                  />
+                                }
+                              />
+                            ))}
+                          </>
+                        }
+                        isCreating={currentCreating === categoryId}
+                        createHandler={() => creatingItemHandler(categoryId)}
+                        creating={
+                          <PackingItem
+                            listId={list.id}
+                            categoryId={categoryId}
+                            packId={'creating'}
+                            name={''}
+                            isChecked={false}
+                            isEditing={true}
+                            updateItem={updateItem}
+                            mode={activeMode}
+                          />
+                        }
+                      >
+                        <PackingCategory
+                          categoryId={categoryId}
+                          listId={list.id}
+                          name={name}
+                          updateCategory={updateCategory}
+                          modalHandler={() =>
+                            bottomModalOpenHandler({
+                              ...initialFocus,
+                              type: 'category',
+                              categoryId,
+                              title: name,
+                            })
+                          }
+                          isEditing={currentEditing === categoryId}
+                        />
+                      </PackagesWithCategory>
+                    ))}
+                    {currentCreatingCategory === list.id && (
+                      <PackagesWithCategory>
+                        <PackingCategory
+                          categoryId={'creating'}
+                          listId={list.id}
+                          name={''}
+                          updateCategory={updateCategory}
+                          isEditing={true}
+                        />
+                      </PackagesWithCategory>
+                    )}
+                    <StyledScrollBlock />
+                  </StyledBody>
+                </SwiperSlide>
+              );
+            })}
+          </Swiper>
+          <FunctionSection>
+            <AddTemplateButton
+              onClick={() =>
+                updateRemainingInfo(
+                  { listId: info.id, isSaved: info.togetherPackingList.isSaved },
+                  'save',
+                )
+              }
+            >
+              {info.togetherPackingList.isSaved ? '템플릿 업데이트' : '나만의 템플릿으로 추가'}
+            </AddTemplateButton>
+          </FunctionSection>
+        </StyledTogetherLanding>
 
-      {packerModalOpen && (
-        <PackerModal
-          members={members.member}
-          modalHandler={packerModalCloseHandler}
-          packId={currentFocus.packId}
-          listId={info.togetherPackingList.id}
-          updatePacker={updatePacker}
-        />
-      )}
-      {isFresh && <ModalForInvitation inviteCode={info.togetherPackingList.inviteCode} />}
+        {packerModalOpen && (
+          <PackerModal
+            members={members.member}
+            modalHandler={packerModalCloseHandler}
+            packId={currentFocus.packId}
+            listId={info.togetherPackingList.id}
+            updatePacker={updatePacker}
+          />
+        )}
+        {isFresh && <ModalForInvitation inviteCode={info.togetherPackingList.inviteCode} />}
 
-      {bottomModalOpen && (
-        <PackingListBottomModal
-          onEdit={onEdit}
-          onDelete={onDelete}
-          closeModal={bottomModalCloseHandler}
-          content={currentFocus.title}
-        />
-      )}
-      {/* {addTemplateModalOpen && (
+        {bottomModalOpen && (
+          <PackingListBottomModal
+            onEdit={onEdit}
+            onDelete={onDelete}
+            closeModal={bottomModalCloseHandler}
+            content={currentFocus.title}
+          />
+        )}
+        {/* {addTemplateModalOpen && (
         <ModalForAddToTemplate title={header.title} onClick={addTemplateModalCloseHandler} />
       )} */}
-    </Layout>
+      </Layout>
+    </>
   );
 }
 

--- a/components/together/invited/InvitedLanding.tsx
+++ b/components/together/invited/InvitedLanding.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { authUserAtom, invitationAtom } from '../../../utils/recoil/atom/atom';
 import useAPI from '../../../utils/hooks/useAPI';
 import ModalForInvited from '../../../components/common/ModalForInvited';
+import HeadMeta from '../../HeadMeta';
 
 function InvitedLanding() {
   const router = useRouter();
@@ -47,7 +48,16 @@ function InvitedLanding() {
   });
 
   if (!info) return null;
-  return !user.isAlreadyUser ? <ModalForInvited title={info.title} /> : null;
+  return !user.isAlreadyUser ? (
+    <>
+      <HeadMeta
+        title={info.title}
+        description={`[${info.title}] 패킹리스트가 공유되었어요!`}
+        url={window.location.href}
+      />
+      <ModalForInvited title={info.title} />
+    </>
+  ) : null;
 }
 
 export default InvitedLanding;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "husky": ">=6",
     "lint-staged": ">=10",
     "next-cookies": "^2.0.3",
+    "next-seo": "^5.15.0",
     "prettier": "^2.7.1",
     "typescript": "^4.8.2"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,7 @@ import { AsyncBoundary } from '../utils/AsyncBoundary';
 import React from 'react';
 import GoogleTagManager from '../components/GoogleTagManager';
 import { AxiosInterceptor } from '../utils/axios';
+import HeadMeta from '../components/HeadMeta';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [show, setShow] = useState(false);
@@ -51,6 +52,7 @@ function MyApp({ Component, pageProps }: AppProps) {
               <Hydrate state={pageProps?.dehydratedState}>
                 <AsyncBoundary>
                   <GlobalStyle />
+                  <HeadMeta />
                   <Component {...pageProps} />
                   <InstallGuide />
                 </AsyncBoundary>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -44,30 +44,10 @@ class MyDocument extends Document {
           <Script src="https://www.googleoptimize.com/optimize.js?id=OPT-KC3RPLW"></Script>
           {/* 검색엔진이 대부분 무시하는 추세 */}
           {/* <meta name="keywords" content="짐,짐 챙기기,여행 짐,여행 체크리스트" /> */}
-          {/* <HeadMeta /> */}
           <meta
             name="viewport"
             content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width"
           />
-          <meta
-            name="description"
-            content={'내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!'}
-          />
-          <meta property="og:locale" content="ko" />
-          <meta property="og:site_name" content="Packman" />
-          <meta property="og:type" content="website" />
-          <meta
-            property="og:title"
-            content={'팩맨 Packman - 내 손안 짐 챙김 도우미'}
-            key="og:title"
-          />
-          <meta
-            property="og:description"
-            content={'내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!'}
-            key="og:description"
-          />
-          <meta property="og:image" content="/og.jpg" />
-          <meta property="og:url" content="https://www.packman.kr" key="og:url" />
           {/* pwa */}
           <meta name="theme-color" content="#fff" />
 

--- a/pages/together/invited/index.tsx
+++ b/pages/together/invited/index.tsx
@@ -12,21 +12,3 @@ function Invited() {
 }
 
 export default Invited;
-
-// export const getServerSideProps: GetServerSideProps = async (context) => {
-//   const { inviteCode } = context.query;
-
-//   const { data }: AxiosResponse<GetSharedPackingListDetailOutput> = await axios.get(
-//     `${process.env.NEXT_PUBLIC_END}/list/together/share/${inviteCode}`,
-//   );
-//   const {
-//     data: { title },
-//   } = data;
-
-//   return {
-//     props: {
-//       title,
-//       description: '내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!',
-//     },
-//   };
-// };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3675,6 +3675,11 @@ next-pwa@^5.5.4:
     workbox-webpack-plugin "^6.5.3"
     workbox-window "^6.5.3"
 
+next-seo@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.15.0.tgz#b1a90508599774982909ea44803323c6fb7b50f4"
+  integrity sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==
+
 next@12.2.0:
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/next/-/next-12.2.0.tgz#aef47cd96b602bc1307d1dcf9a1ee3e753845544"


### PR DESCRIPTION
### 구현 사항
![image](https://user-images.githubusercontent.com/66051416/222944129-94826074-50e4-4445-b13b-ee48dd0c4dfb.png)

- [x] [next-seo](https://github.com/garmeeh/next-seo) 플러그인을 통해 함께 패킹 링크 공유 시 해당 리스트의 title을 동적으로 보여줄 수 있도록 `HeadMeta` 컴포넌트를 수정했습니다.
TogetherLanding과 AloneLanding, InvitedLanding 컴포넌트에서 각각 `title`, `description`, `url`을 HeadMeta 컴포넌트에 props로 넘겨주어 적용해주었습니다.
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------

