### PR TITLE
PK-23 [멤버 관리] 멤버 편집 중 멤버 갱신 오류 수정

### DIFF
--- a/components/memberManage/ManagingMemberLanding.tsx
+++ b/components/memberManage/ManagingMemberLanding.tsx
@@ -27,15 +27,15 @@ function ManagingMemberLanding() {
   const router = useRouter();
   const { id } = router.query;
 
+  const [isEditing, setIsEditing] = useState<boolean>(false);
   const getMembers = useAPI((api) => api.packingList.together.getMembers);
   const { data } = useQuery(['getMembers', id], () => getMembers(id as string), {
-    enabled: !!id,
+    enabled: !!id && !isEditing,
     refetchInterval: 3000,
   });
 
   const user = useRecoilValue(authUserAtom);
   const userId = user.id;
-  const [isEditing, setIsEditing] = useState<boolean>(false);
   const [hasCopied, setHasCopied] = useState<boolean>(false);
   const [oldMembers, setOldMembers] = useState<Imember[]>([]);
   const [willBeDeleted, setWillBeDeleted] = useState<string[]>([]);
@@ -90,7 +90,7 @@ function ManagingMemberLanding() {
     });
 
     client.setQueryData(['getMembers', id], newPrev);
-    setWillBeDeleted((prev) => [...prev, memberId]);
+    setWillBeDeleted((prev) => [...new Set([...prev, memberId])]);
   };
 
   const clickInvitingButton = () => {


### PR DESCRIPTION
### [PK-23]

### 구현 사항

- [x] isEditing이 아닐 때만 멤버 조회 요청하도록 수정 (기존의 경우 편집 중 멤버를 삭제해도 3초 뒤 다시 갱신)
- [x] 편집 > 삭제 > 취소를 반복 할 경우 삭제 할 id 목록에 같은 id가 중복으로 쌓이는 문제 수정
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PK-23]: https://packman-team.atlassian.net/browse/PK-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ