### PR TITLE
PM-111 [혼자 패킹 리스트] 여러 리스트 삭제 체크를 하고 화면을 내리면 삭제 체크가 사라진다

### DIFF
--- a/components/packingList/PackingListLanding.tsx
+++ b/components/packingList/PackingListLanding.tsx
@@ -35,7 +35,7 @@ function PackingListLanding() {
 
   const swipe = (item?: string) => {
     if (!item) {
-      resetListItem();
+      !isDeletingMode && resetListItem();
       return;
     }
     const updatedListItem = new Set(isSwiped);


### PR DESCRIPTION
### [PM-111]

### 구현 사항

- [x] swipe 시 스와이프 여부, 삭제 선택 여부를 나타내는 리스트 변수들을 모두 초기화하는 `resetListItem` 메소드를 호출하고 있었는데, `isDeletingMode(현재 삭제 선택 모드인지 여부를 나타내는 boolean 변수)`가 아닐 때만 reset하도록 고쳤습니다.
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PM-111]: https://packman-team.atlassian.net/browse/PM-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ