### PR TITLE
[QA] 카카오로그인 버튼 하단의 [이용약관]과 [개인정보 처리 방침] 링크에 정상적으로 접속 안됨 이슈 해결

### DIFF
--- a/components/login/LoginLanding.tsx
+++ b/components/login/LoginLanding.tsx
@@ -37,7 +37,8 @@ function LoginLanding() {
         </LogoWrapper>
         <Title>내 손안 짐 챙김 도우미</Title>
       </LogoAndTitle>
-      <ButtonsContainer>
+
+      <LoginContainer>
         <Link href={KAKAO_HREF}>
           <LoginButton id="custom-login-btn">
             <Image src={KakaoLogin} alt="카카오 로그인 버튼" layout="fill" />
@@ -47,7 +48,7 @@ function LoginLanding() {
           로그인 시 <Link href={TEMRS_OF_SERVICE}>이용약관</Link>과{' '}
           <Link href={PRIVACY_POLICY}>개인정보 처리 방침</Link>에 동의하게 됩니다.
         </p>
-      </ButtonsContainer>
+      </LoginContainer>
     </StyledRoot>
   );
 }
@@ -111,7 +112,7 @@ const Title = styled.div`
   }
 `;
 
-const ButtonsContainer = styled.div`
+const LoginContainer = styled.div`
   width: 100%;
   position: absolute;
   top: 75%;

--- a/components/login/LoginLanding.tsx
+++ b/components/login/LoginLanding.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router';
 import { useInvitation, useKaKaoLogin } from '../../utils/hooks/auth';
 import { useRecoilValue } from 'recoil';
 import { authUserAtom } from '../../utils/recoil/atom/atom';
-import { KAKAO_HREF } from '../../utils/constant';
+import { KAKAO_HREF, PRIVACY_POLICY, TEMRS_OF_SERVICE } from '../../utils/constant';
 
 function LoginLanding() {
   const router = useRouter();
@@ -43,6 +43,10 @@ function LoginLanding() {
             <Image src={KakaoLogin} alt="카카오 로그인 버튼" layout="fill" />
           </LoginButton>
         </Link>
+        <p>
+          로그인 시 <Link href={TEMRS_OF_SERVICE}>이용약관</Link>과{' '}
+          <Link href={PRIVACY_POLICY}>개인정보 처리 방침</Link>에 동의하게 됩니다.
+        </p>
       </ButtonsContainer>
     </StyledRoot>
   );
@@ -116,6 +120,19 @@ const ButtonsContainer = styled.div`
   align-items: center;
   gap: 0.8em;
 
+  & > p {
+    font-size: 1.2rem;
+    font-weight: 400;
+    color: ${packmanColors.pmDeepGrey};
+
+    position: absolute;
+    top: calc(100% + 1.2rem);
+    left: 50%;
+    width: 200%;
+    transform: translateX(-50%);
+    text-align: center;
+  }
+
   @media screen and (min-width: 700px) {
     font-size: 1.5rem;
   }
@@ -139,19 +156,5 @@ const LoginButton = styled.div`
     bottom: calc(100% + 1.2rem);
     left: 50%;
     transform: translateX(-50%);
-  }
-
-  &::after {
-    content: '로그인 시 이용약관과 개인정보 처리 방침에 동의하게 됩니다.';
-    font-size: 1.2rem;
-    font-weight: 400;
-    color: ${packmanColors.pmDeepGrey};
-
-    position: absolute;
-    top: calc(100% + 1.2rem);
-    left: 50%;
-    width: 200%;
-    transform: translateX(-50%);
-    text-align: center;
   }
 `;

--- a/utils/constant/index.ts
+++ b/utils/constant/index.ts
@@ -2,6 +2,9 @@ export const KAKAO_HREF = `https://kauth.kakao.com/oauth/authorize?client_id=${
   process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID
 }&redirect_uri=${encodeURI(process.env.NEXT_PUBLIC_REDIRECT ?? '')}&response_type=code`;
 
+export const PRIVACY_POLICY = 'https://www.notion.so/c9e91c3d19554ef7a01737d3fba6e102';
+export const TEMRS_OF_SERVICE = 'https://www.notion.so/99197c3491fe477ea9d69ed131cf4087';
+
 export const googleTagManagerId = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || '';
 
 declare global {


### PR DESCRIPTION
### [PK-27]

### 구현 사항
![image](https://user-images.githubusercontent.com/66051416/229330354-a163e81c-ec12-4dc0-bb4e-b056f23d8492.png)

- [x] 기존에 `after` 가상 요소로 구현되어 있던 이용약관 및 개인정보 처리 텍스트를 수정했습니다.
```css
&::after {
    content: '로그인 시 이용약관과 개인정보 처리 방침에 동의하게 됩니다.';
}
```

1. 텍스트를 눌렀을 때 카카오 로그인 리다이렉트가 발생하지 않도록 위치를 Link 태그 바깥으로 이동시키고, 
기존의  `ButtonsContainer` 에서 `LoginContainer`로 스타일 컴포넌트 이름을 변경했어요.

2. 링크 상수는 KAKAO_HREF가 저장되어 있는 utils/constant 에 같이 넣어놨어요.
```tsx
<LoginContainer>
        <Link href={KAKAO_HREF}>
          <LoginButton id="custom-login-btn">
            <Image src={KakaoLogin} alt="카카오 로그인 버튼" layout="fill" />
          </LoginButton>
        </Link>

        <p>
          로그인 시 <Link href={TEMRS_OF_SERVICE}>이용약관</Link>과{' '}
          <Link href={PRIVACY_POLICY}>개인정보 처리 방침</Link>에 동의하게 됩니다.
        </p>
</LoginContainer>
```

-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PK-27]: https://packman-team.atlassian.net/browse/PK-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ