### PR TITLE
feat/PK-28: 함께패킹 담당자가 존재하는 경우 핑크으로 활성화

### DIFF
--- a/components/together/PackerModal.tsx
+++ b/components/together/PackerModal.tsx
@@ -19,18 +19,20 @@ interface PackerModalProps {
   }[];
   packId: string;
   listId: string;
+  selectedPacker: { id: string; nickname: string } | null;
+
   modalHandler: () => void;
   updatePacker: (payload: PackerInfoPayload) => void;
 }
 
 function PackerModal(props: PackerModalProps) {
-  const { members, modalHandler, packId, listId, updatePacker } = props;
+  const { members, modalHandler, packId, listId, updatePacker, selectedPacker } = props;
 
   const TICK = 30;
   const ITERATOR = Array(TICK).fill('').entries();
   const ID_LIST = members.map(({ id }) => id);
   const drawId = () => Math.floor(Math.random() * members.length);
-  const [selected, setSelected] = useState('');
+  const [selected, setSelected] = useState(selectedPacker ? selectedPacker.id : '');
 
   /** @todo 랜덤 배정 로직 수정 */
   const draw = () => {

--- a/components/together/TogetherLanding.tsx
+++ b/components/together/TogetherLanding.tsx
@@ -26,9 +26,6 @@ import useHide from '../../utils/hooks/useHide';
 import { GetTogetherPackingListBodyOutput } from '../../service/packingList/together';
 import { AxiosError } from 'axios';
 import useDynamic from '../../utils/hooks/useDynamic';
-import HeadMeta from '../HeadMeta';
-import apiService from '../../service';
-import { NextPageContext } from 'next';
 
 interface FocusInfo {
   type: 'category' | 'item';
@@ -63,6 +60,9 @@ function TogetherLanding() {
   const [packerModalOpen, setPackerModalOpen] = useState(false);
   const [addTemplateModalOpen, setAddTemplateModalOpen] = useState(false);
   const [activeMode, setActiveMode] = useState(0);
+  const [selectedPacker, setSelectedPacker] = useState<{ id: string; nickname: string } | null>(
+    null,
+  );
 
   const [currentCreatingCategory, setCurrentCreatingCategory] = useState('');
   const [currentCreating, setCurrentCreating] = useState('');
@@ -277,7 +277,14 @@ function TogetherLanding() {
     setCurrentFocus(initialFocus);
     setBottomModalOpen(false);
   };
-  const packerModalOpenHandler = (packId: string) => {
+  const packerModalOpenHandler = (
+    packId: string,
+    packer: {
+      id: string;
+      nickname: string;
+    } | null,
+  ) => {
+    setSelectedPacker(packer);
     setCurrentFocus({ ...initialFocus, type: 'item', packId });
     setPackerModalOpen(true);
   };
@@ -683,7 +690,7 @@ function TogetherLanding() {
                               assignee={
                                 <Packer
                                   packer={packer}
-                                  modalHandler={() => packerModalOpenHandler(packId)}
+                                  modalHandler={() => packerModalOpenHandler(packId, packer)}
                                 />
                               }
                             />
@@ -760,6 +767,7 @@ function TogetherLanding() {
           packId={currentFocus.packId}
           listId={info.togetherPackingList.id}
           updatePacker={updatePacker}
+          selectedPacker={selectedPacker}
         />
       )}
       {isFresh && <ModalForInvitation inviteCode={info.togetherPackingList.inviteCode} />}


### PR DESCRIPTION
### [PK-28]

### 구현 사항
데이터 구조가 굉장히 복잡해서 state를 하나 추가했습니다.
 ```tsx
const [selectedPacker, setSelectedPacker] = useState<{ id: string; nickname: string } | null>(null);
```
Packer 컴포넌트를 클릭하면 `packerModalOpenHandler(packId)` 핸들러가 작동하는데, 파라미터에 담당자 정보를 의미하는 `packer`를 추가했어요. 클릭했을 때 packer 정보를 받아서 setState 해줬습니다.

PackerModal 컴포넌트에 `selectedPacker` props를 추가로 넘겨서 이미 배정된 담당자가 존재하면 핑크색으로 활성화되도록 수정했습니다.

-----------------
### Message
-----------
### Need Review



------------
### Reference
-------------

