### PR TITLE
[PK-18] Dynamic OpenGraph Tag 해결

### DIFF
--- a/components/common/Layout.tsx
+++ b/components/common/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { packmanColors } from '../../styles/color';
 import useGlobalState from '../../utils/hooks/useGlobalState';
@@ -20,9 +20,13 @@ interface LayoutProps {
 
 function Layout(props: LayoutProps) {
   const { children, back, title, icon, option, padding, noHeader, listId, folderId } = props;
-
   const [scroll] = useGlobalState<boolean>('scroll');
-  const optionEl = document.querySelector('.layout_option');
+  const [optionEl, setOptionEl] = useState<Element | null>(null);
+
+  useEffect(() => {
+    const layoutOption = document.querySelector('.layout_option') || null;
+    setOptionEl(layoutOption);
+  }, []);
 
   return (
     <StyledRoot>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,12 +11,9 @@ import { AsyncBoundary } from '../utils/AsyncBoundary';
 import React from 'react';
 import GoogleTagManager from '../components/GoogleTagManager';
 import { AxiosInterceptor } from '../utils/axios';
-import HeadMeta from '../components/HeadMeta';
 import { DefaultSeo } from 'next-seo';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [show, setShow] = useState(false);
-
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -36,16 +33,12 @@ function MyApp({ Component, pageProps }: AppProps) {
     return () => window.removeEventListener('resize', setScreenSize);
   });
 
-  useEffect(() => {
-    setShow(true);
-  }, []);
-
-  if (!show) return null;
-
   return (
     <>
-      <HeadMeta />
       <DefaultSeo
+        title="팩맨 Packman - 내 손안 짐챙김 도우미"
+        description="내 손안 짐 챙김 도우미, 팩맨. 지금 바로 팩맨을 사용해보세요!"
+        canonical="https:/www.packman.kr"
         openGraph={{
           type: 'website',
           locale: 'en_IE',

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,23 +1,17 @@
-import { ServerStyleSheets } from '@mui/styles';
-import Document, {
-  Html,
-  Head,
-  Main,
-  NextScript,
-  DocumentContext,
-  DocumentInitialProps,
-} from 'next/document';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 import Script from 'next/script';
 import { googleTagManagerId } from '../utils/constant/index';
+import { ServerStyleSheet } from 'styled-components';
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-    const materialSheets = new ServerStyleSheets();
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
+
     try {
       ctx.renderPage = () =>
         originalRenderPage({
-          enhanceApp: (App) => (props) => materialSheets.collect(<App {...props} />),
+          enhanceApp: (App: any) => (props: any) => sheet.collectStyles(<App {...props} />),
         });
 
       const initialProps = await Document.getInitialProps(ctx);
@@ -26,12 +20,12 @@ class MyDocument extends Document {
         styles: (
           <>
             {initialProps.styles}
-            {materialSheets.getStyleElement()}
+            {sheet.getStyleElement()}
           </>
         ),
       };
     } finally {
-      //   materialSheets.seal();
+      sheet.seal();
     }
   }
 

--- a/pages/alone/index.tsx
+++ b/pages/alone/index.tsx
@@ -1,12 +1,51 @@
+import { NextPageContext } from 'next';
+import { useRouter } from 'next/router';
 import AloneLanding from '../../components/alone/AloneLanding';
+import HeadMeta from '../../components/HeadMeta';
+import apiService from '../../service';
 import { AsyncBoundary } from '../../utils/AsyncBoundary';
+import { client } from '../../utils/axios';
 
-function Alone() {
+interface AloneProps {
+  title: string;
+}
+function Alone(props: AloneProps) {
+  const { title: headerTitle } = props;
+  const router = useRouter();
+
   return (
-    <AsyncBoundary>
-      <AloneLanding />
-    </AsyncBoundary>
+    <>
+      <HeadMeta
+        title={headerTitle}
+        description={`[${headerTitle}] 패킹리스트가 공유되었어요!`}
+        url={`${process.env.NEXT_PUBLIC_DOMAIN}/${router.asPath}`}
+      />
+      <AsyncBoundary>
+        <AloneLanding />
+      </AsyncBoundary>
+    </>
   );
 }
 
 export default Alone;
+
+Alone.getInitialProps = async function ({ req, query }: NextPageContext) {
+  const getPackingListHeader = apiService.packingList.together.getPackingListHeader;
+  const cookie = req?.headers?.cookie?.split(';');
+  const arr = cookie ? cookie[1].split(';') : [];
+  const accessToken = arr.reduce((acc, curr) => {
+    const [key, value] = curr.trim().split('=');
+    if (key === 'accessToken') {
+      return value;
+    }
+    return acc;
+  }, '');
+
+  client.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+  const { data: header } = await getPackingListHeader(query.id as string, true);
+  const { title } = header;
+  return {
+    title,
+  };
+};

--- a/pages/alone/invited/index.tsx
+++ b/pages/alone/invited/index.tsx
@@ -1,12 +1,54 @@
-import InvitedLanding from '../../../components/alone/invited/InvitedLanding';
+import { NextPageContext } from 'next';
+import { useRouter } from 'next/router';
+import HeadMeta from '../../../components/HeadMeta';
+import InvitedLanding from '../../../components/together/invited/InvitedLanding';
+import apiService from '../../../service';
 import { AsyncBoundary } from '../../../utils/AsyncBoundary';
+import { client } from '../../../utils/axios';
 
-function InvitedForAlone() {
+interface InvitedProps {
+  title: string;
+}
+function Invited(props: InvitedProps) {
+  const { title } = props;
+  const router = useRouter();
+
   return (
-    <AsyncBoundary>
-      <InvitedLanding />
-    </AsyncBoundary>
+    <>
+      <HeadMeta
+        title={title}
+        description={`[${title}] 패킹리스트가 공유되었어요!`}
+        url={`${process.env.NEXT_PUBLIC_DOMAIN}/${router.asPath}`}
+      />
+      <AsyncBoundary>
+        <InvitedLanding />;
+      </AsyncBoundary>
+    </>
   );
 }
 
-export default InvitedForAlone;
+export default Invited;
+
+Invited.getInitialProps = async function ({ req, query }: NextPageContext) {
+  const getSharedPackingListDetail = apiService.packingList.common.getSharedPackingListDetail;
+  const cookie = req?.headers?.cookie?.split(';');
+  const arr = cookie ? cookie[1].split(';') : [];
+  const accessToken = arr.reduce((acc, curr) => {
+    const [key, value] = curr.trim().split('=');
+    if (key === 'accessToken') {
+      return value;
+    }
+    return acc;
+  }, '');
+
+  client.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+  const { data: info } = await getSharedPackingListDetail({
+    type: 'together',
+    inviteCode: query.inviteCode as string,
+  });
+  const { title } = info;
+  return {
+    title,
+  };
+};

--- a/pages/together/index.tsx
+++ b/pages/together/index.tsx
@@ -1,12 +1,51 @@
+import { useRouter } from 'next/router';
+import HeadMeta from '../../components/HeadMeta';
 import TogetherLanding from '../../components/together/TogetherLanding';
 import { AsyncBoundary } from '../../utils/AsyncBoundary';
+import { NextPageContext } from 'next';
+import apiService from '../../service';
+import { client } from '../../utils/axios';
 
-function Together() {
+interface TogetherProps {
+  title: string;
+}
+function Together(props: TogetherProps) {
+  const { title: headerTitle } = props;
+  const router = useRouter();
+
   return (
-    <AsyncBoundary>
-      <TogetherLanding />
-    </AsyncBoundary>
+    <>
+      <HeadMeta
+        title={headerTitle}
+        description={`[${headerTitle}] 패킹리스트가 공유되었어요!`}
+        url={`${process.env.NEXT_PUBLIC_DOMAIN}/${router.asPath}`}
+      />
+      <AsyncBoundary>
+        <TogetherLanding />
+      </AsyncBoundary>
+    </>
   );
 }
 
 export default Together;
+
+Together.getInitialProps = async function ({ req, query }: NextPageContext) {
+  const getPackingListHeader = apiService.packingList.together.getPackingListHeader;
+  const cookie = req?.headers?.cookie?.split(';');
+  const arr = cookie ? cookie[1].split(';') : [];
+  const accessToken = arr.reduce((acc, curr) => {
+    const [key, value] = curr.trim().split('=');
+    if (key === 'accessToken') {
+      return value;
+    }
+    return acc;
+  }, '');
+
+  client.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+  const { data: header } = await getPackingListHeader(query.id as string, false);
+  const { title } = header;
+  return {
+    title,
+  };
+};


### PR DESCRIPTION
### [PK-18]

### 구현 사항

- [x] _app.tsx에서 `show` 상태로 Next.js의 초기 스타일 적용을 지연시키는 코드를 삭제했습니다. 대신 _document.tsx에서 styled-components의 `ServerStyleSheet`를 이용해서 서버에서 스타일을 적용한 문서를 내려주도록 수정했습니다.  (기존 material-ui의 sheet는 잘 적용이 안됐나봅니다. show를 삭제하면 스타일이 깨지는 현상이 있었습니다.)
- [x] 동적 태그가 필요한 컴포넌트에 SSR을 적용했습니다. getInitialProps로 미리 데이터를 가져와서 html meta tag를 적용해줘야 합니다. 이때 크로스 브라우징을 위해 정규표현식 대신 split() 메소드를 이용한 방식으로 accessToken을 가져왔습니다.
-----------------
### Message
새로 Next.js 프로젝트를 파서 배포해봤는데, app.tsx에서 ealry return하는 코드가 없으면 제대로 작동했습니다. 이번에는 뭔가 정말 해결될 것 같습니다. 제발...'

-----------
### Need Review



------------
### Reference
-------------



[PK-18]: https://packman-team.atlassian.net/browse/PK-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ