### PR TITLE
feat/PK-18: invited 함께, 혼자 SSR 코드 수정

### DIFF
--- a/components/together/invited/InvitedLanding.tsx
+++ b/components/together/invited/InvitedLanding.tsx
@@ -5,7 +5,6 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { authUserAtom, invitationAtom } from '../../../utils/recoil/atom/atom';
 import useAPI from '../../../utils/hooks/useAPI';
 import ModalForInvited from '../../../components/common/ModalForInvited';
-import HeadMeta from '../../HeadMeta';
 
 function InvitedLanding() {
   const router = useRouter();
@@ -48,16 +47,7 @@ function InvitedLanding() {
   });
 
   if (!info) return null;
-  return !user.isAlreadyUser ? (
-    <>
-      <HeadMeta
-        title={info.title}
-        description={`[${info.title}] 패킹리스트가 공유되었어요!`}
-        url={window.location.href}
-      />
-      <ModalForInvited title={info.title} />
-    </>
-  ) : null;
+  return !user.isAlreadyUser ? <ModalForInvited title={info.title} /> : null;
 }
 
 export default InvitedLanding;

--- a/pages/alone/invited/index.tsx
+++ b/pages/alone/invited/index.tsx
@@ -1,10 +1,9 @@
 import { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import HeadMeta from '../../../components/HeadMeta';
-import InvitedLanding from '../../../components/together/invited/InvitedLanding';
+import InvitedLanding from '../../../components/alone/invited/InvitedLanding';
 import apiService from '../../../service';
 import { AsyncBoundary } from '../../../utils/AsyncBoundary';
-import { client } from '../../../utils/axios';
 
 interface InvitedProps {
   title: string;
@@ -31,20 +30,9 @@ export default Invited;
 
 Invited.getInitialProps = async function ({ req, query }: NextPageContext) {
   const getSharedPackingListDetail = apiService.packingList.common.getSharedPackingListDetail;
-  const cookie = req?.headers?.cookie?.split(';');
-  const arr = cookie ? cookie[1].split(';') : [];
-  const accessToken = arr.reduce((acc, curr) => {
-    const [key, value] = curr.trim().split('=');
-    if (key === 'accessToken') {
-      return value;
-    }
-    return acc;
-  }, '');
-
-  client.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
 
   const { data: info } = await getSharedPackingListDetail({
-    type: 'together',
+    type: 'alone',
     inviteCode: query.inviteCode as string,
   });
   const { title } = info;

--- a/pages/together/invited/index.tsx
+++ b/pages/together/invited/index.tsx
@@ -1,12 +1,42 @@
+import { NextPageContext } from 'next';
 import InvitedLanding from '../../../components/together/invited/InvitedLanding';
+import HeadMeta from '../../../components/HeadMeta';
 import { AsyncBoundary } from '../../../utils/AsyncBoundary';
+import apiService from '../../../service';
+import { useRouter } from 'next/router';
 
-function Invited() {
+interface InvitedProps {
+  title: string;
+}
+function Invited(props: InvitedProps) {
+  const { title } = props;
+  const router = useRouter();
+
   return (
-    <AsyncBoundary>
-      <InvitedLanding />;
-    </AsyncBoundary>
+    <>
+      <HeadMeta
+        title={title}
+        description={`[${title}] 패킹리스트가 공유되었어요!`}
+        url={`${process.env.NEXT_PUBLIC_DOMAIN}/${router.asPath}`}
+      />
+      <AsyncBoundary>
+        <InvitedLanding />;
+      </AsyncBoundary>
+    </>
   );
 }
 
 export default Invited;
+
+Invited.getInitialProps = async function ({ req, query }: NextPageContext) {
+  const getSharedPackingListDetail = apiService.packingList.common.getSharedPackingListDetail;
+
+  const { data: info } = await getSharedPackingListDetail({
+    type: 'together',
+    inviteCode: query.inviteCode as string,
+  });
+  const { title } = info;
+  return {
+    title,
+  };
+};


### PR DESCRIPTION
### [PK-18]

### 구현 사항

- [x] InvitedLanding에 있는 HeadMeta는 불필요해서 삭제했습니다
- [x] 함께 패킹리스트 초대, 혼자 패킹리스트 공유 invited.tsx가 두 개 더라구요. together, alone 잘 구분해서 수정했고, accessToken 관련 코드 삭제했습니다 
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PK-18]: https://packman-team.atlassian.net/browse/PK-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ