### PR TITLE
[PK-31] 폴더 안 패킹리스트 '아직 n개의 짐이 남았어요' 텍스트 미표시

### DIFF
--- a/components/common/BottomModal.tsx
+++ b/components/common/BottomModal.tsx
@@ -101,7 +101,7 @@ const StyledRoot = styled.div`
 
   & > h1 {
     color: ${packmanColors.pmBlack};
-    font-style: ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
     padding-top: 0.8rem;
     padding-bottom: 1rem;
   }
@@ -132,7 +132,7 @@ const StyledButtonWrapper = styled.div`
     height: 8rem;
     border: none;
     border-radius: 0.8rem;
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     background: ${packmanColors.pmBlueGrey};
     color: ${packmanColors.pmDarkGrey};
     /* Safari에서 font color 무시되는 경우를 위한 코드 */

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -128,23 +128,23 @@ const StyledRightContainer = styled.div<{ overlay?: CSSProp }>`
 `;
 
 const StyledDefaultTitle = css`
-  font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+  ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   color: ${packmanColors.black};
 `;
 
 const StyledDefaultSubTitle = css`
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   color: ${packmanColors.pmDeepGrey};
 `;
 
 const StyledDefaultLabel = css`
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   color: ${packmanColors.pmDeepGrey};
   margin-bottom: 0.3rem;
 `;
 
 const StyledDefaultDDay = css`
-  font-style: ${FONT_STYLES.DISPLAY3_EXTRABOLD};
+  ${FONT_STYLES.DISPLAY3_EXTRABOLD};
   color: ${packmanColors.pmGreen};
 `;
 

--- a/components/common/Chip.tsx
+++ b/components/common/Chip.tsx
@@ -15,7 +15,7 @@ export default Chip;
 
 const StyledChip = styled.div`
   width: fit-content;
-  font-style: ${FONT_STYLES.BODY1_REGULAR};
+  ${FONT_STYLES.BODY1_REGULAR};
   padding: 0.1rem 1rem;
   color: ${packmanColors.pmBlack};
   border-radius: 1.2rem;

--- a/components/common/Error.tsx
+++ b/components/common/Error.tsx
@@ -44,13 +44,13 @@ const StyledRoot = styled.div`
 `;
 
 const ErrorTitle = styled.div`
-  font-style: ${FONT_STYLES.DISPLAY2_SEMIBOLD};
+  ${FONT_STYLES.DISPLAY2_SEMIBOLD};
   color: ${packmanColors.pmBlack};
   margin: 3rem 0 1rem 0;
 `;
 
 const ErrorSubTitle = styled.div`
-  font-style: ${FONT_STYLES.BODY3_REGULAR};
+  ${FONT_STYLES.BODY3_REGULAR};
   color: ${packmanColors.pmBlack};
 `;
 

--- a/components/common/PackingListBottomModal.tsx
+++ b/components/common/PackingListBottomModal.tsx
@@ -110,7 +110,7 @@ const StyledRoot = styled.div`
 
   & > h1 {
     color: #282828;
-    font-style: ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
+    ${FONT_STYLES.SUBHEAD1_SEMIBOLD};
   }
 
   @keyframes appear {
@@ -140,7 +140,7 @@ const StyledButtonWrapper = styled.div`
     padding: 0;
     border: none;
     border-radius: 0.8rem;
-    font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+    ${FONT_STYLES.BODY2_SEMIBOLD};
     background: ${packmanColors.pmBlueGrey};
     -webkit-text-fill-color: ${packmanColors.pmDarkGrey};
   }

--- a/components/folder/FloatActionButton.tsx
+++ b/components/folder/FloatActionButton.tsx
@@ -172,7 +172,7 @@ export const StyledList = styled.li<{ open: boolean; index: number }>`
 
   span:last-child {
     /* '폴더 추가' 중앙 정렬을 위한 코드 */
-    font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+    ${FONT_STYLES.BODY4_SEMIBOLD};
     padding-left: ${({ index }) => (index === 2 ? '3.2rem' : '1.4rem')};
     flex-shrink: 0;
   }

--- a/components/memberManage/ManagingMemberLanding.tsx
+++ b/components/memberManage/ManagingMemberLanding.tsx
@@ -240,11 +240,11 @@ const WithMembersLabelAndEdit = styled.div`
 `;
 
 const WithMembersLabel = styled.h1`
-  font-style: ${FONT_STYLES.HEADLINE2_SEMIBOLD};
+  ${FONT_STYLES.HEADLINE2_SEMIBOLD};
 `;
 
 const WithMembersEditButton = styled.div`
-  font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+  ${FONT_STYLES.BODY2_SEMIBOLD};
   color: ${packmanColors.pmDarkGrey};
 `;
 
@@ -290,7 +290,7 @@ const MemberImage = styled.div<{ index: number }>`
 `;
 
 const MemberName = styled.div`
-  font-style: ${FONT_STYLES.BODY2_SEMIBOLD};
+  ${FONT_STYLES.BODY2_SEMIBOLD};
   color: ${packmanColors.pmDarkGrey};
 `;
 
@@ -300,7 +300,7 @@ const InviteOtherMember = styled.div<{ length: number }>`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-style: ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
+  ${FONT_STYLES.SUBHEAD2_SEMIBOLD};
   color: ${packmanColors.pmGrey};
   white-space: nowrap;
 `;
@@ -318,7 +318,7 @@ const InvitingButton = styled.div<{ hasCopied: boolean }>`
   color: white;
   background-color: ${packmanColors.pmPink};
   border-radius: 0.8rem;
-  font-style: ${FONT_STYLES.BODY4_SEMIBOLD};
+  ${FONT_STYLES.BODY4_SEMIBOLD};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -327,7 +327,7 @@ const InvitingButton = styled.div<{ hasCopied: boolean }>`
     hasCopied &&
     css`
       &::after {
-        font-style: ${FONT_STYLES.BODY1_REGULAR};
+        ${FONT_STYLES.BODY1_REGULAR};
         color: ${packmanColors.pmDarkGrey};
         position: absolute;
         bottom: 12.5rem;

--- a/components/packingList/SwipeableListItem.tsx
+++ b/components/packingList/SwipeableListItem.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Chip from '../common/Chip';
 import Card from '../common/Card';
-import { Utility } from '../../utils/Utility';
+import { FONT_STYLES } from '../../styles/font';
 
 interface PackingList {
   id: string;
@@ -93,6 +93,24 @@ export default function SwipeableListItem(props: ItemProps) {
     }
   };
 
+  const getRemainDesc = () => {
+    const remainNum = parseInt(packRemainNum);
+    const totalNum = parseInt(packTotalNum);
+    if (remainNum) {
+      return (
+        <span>
+          아직 <em>{packRemainNum}</em>개의 짐이 남았어요!
+        </span>
+      );
+    } else if (totalNum !== 0) {
+      return (
+        <span>
+          <em>패킹</em>이 완료되었어요!
+        </span>
+      );
+    }
+  };
+
   return (
     <StyledRoot isDeletingMode={isDeletingMode}>
       {isDeletingMode && (
@@ -124,9 +142,7 @@ export default function SwipeableListItem(props: ItemProps) {
               </Card.SubTitle>
             </Card.LeftContainer>
             <Card.RightContainer overlay={rightContainerStyle}>
-              <Card.Description overlay={descriptionStyle}>
-                {Utility.getRemainPackDesc(packRemainNum, departureDate)}
-              </Card.Description>
+              <Card.Description overlay={descriptionStyle}>{getRemainDesc()}</Card.Description>
             </Card.RightContainer>
             <Card.Icon icon={iRightArrow} />
           </Card>
@@ -262,7 +278,9 @@ const rightContainerStyle = css`
 
 const descriptionStyle = css`
   & > span {
+    ${FONT_STYLES.BODY1_REGULAR}
     & > em {
+      font-weight: 600;
       color: ${packmanColors.pmPink};
     }
   }


### PR DESCRIPTION
### [PK-31]

### 구현 사항
![image](https://user-images.githubusercontent.com/66051416/229797748-a2852637-6e24-4b8b-b339-38973f30d471.png)
```tsx
const getRemainDesc = () => {
    const remainNum = parseInt(packRemainNum);
    const totalNum = parseInt(packTotalNum);
    if (remainNum) {
      return (
        <span>
          아직 <em>{packRemainNum}</em>개의 짐이 남았어요!
        </span>
      );
    } else if (totalNum !== 0) {
      return (
        <span>
          <em>패킹</em>이 완료되었어요!
        </span>
      );
    }
  };
```
- [x] 폴더 안 패킹리스트 뷰 '아직 n개의 짐이 남았어요!' 문구가 날짜에 관계없이 뜰 수 있도록 Utility.getRemainDesc() 메소드를 제거했습니다. 해당 컴포넌트 내에서 getRemainDesc() 함수를 생성하고, 기존 조건도 좀더 컴팩트하게 수정해서 Element를 반환하도록 고쳤습니다.

- [x] 폰트 상수를 쓸 때 `font-style` 속성이 없어야 적용됩니다. 왜냐하면 FONT_STYLES 자체가 font-style 속성을 가지고 있기 떄문입니다. font-style을 사용하고 있는 모든 페이지에서 해당 속성을 제거해줬습니다.
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PK-31]: https://packman-team.atlassian.net/browse/PK-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ