### PR TITLE
fix/PK-36:리스트 작성하기 빈 폴더 생성 이슈 수정

### DIFF
--- a/components/alone/listIntro/ListIntroLanding.tsx
+++ b/components/alone/listIntro/ListIntroLanding.tsx
@@ -246,7 +246,9 @@ function ListIntroLanding() {
               placeholder="폴더 이름을 입력하세요"
               maxLength={10}
             />
-            <button onClick={handleAddFolder}>생성</button>
+            <button onClick={handleAddFolder} disabled={folderName === ''}>
+              생성
+            </button>
           </StyledFolderInputContent>
           <StyledTagContainer>
             {isAloned


### PR DESCRIPTION
### [PK-36](https://packman-team.atlassian.net/browse/PK-36)

### 구현 사항

- [x] 리스트 작성하기 페이지에서 빈 폴더 생성 이슈 해결 - 폴더 명이 없을 때 폴더 생성 버튼을 비활성화함
-----------------
### Message

-----------
### Need Review



------------
### Reference
-------------



[PK-36]: https://packman-team.atlassian.net/browse/PK-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ