### PR TITLE
[hotfix] 회원가입 후 토큰이 저장 안되는 오류 수정 

### DIFF
--- a/components/profile/SelectProfileSection.tsx
+++ b/components/profile/SelectProfileSection.tsx
@@ -8,6 +8,7 @@ import { ProfileList } from '../../utils/profileImages';
 import { FONT_STYLES } from '../../styles/font';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { authUserAtom, creatingUserAtom, invitationAtom } from '../../utils/recoil/atom/atom';
+import cookie from 'react-cookies';
 
 interface SelectProfileSectionProps {
   isEditing?: boolean;
@@ -29,7 +30,12 @@ function SelectProfileSection(props: SelectProfileSectionProps) {
 
   //프로필 생성
   const addUserProfile = useAPI((api) => api.user.addUserProfile);
-  const { mutate: addUserProfileMutate } = useMutation(addUserProfile);
+  const { mutate: addUserProfileMutate } = useMutation(addUserProfile, {
+    onSuccess({ data }) {
+      cookie.save('accessToken', data.accessToken, {});
+      cookie.save('refreshToken', data.refreshToken, {});
+    },
+  });
 
   //프로필 수정
   const updateUserProfile = useAPI((api) => api.user.updateUserProfile);

--- a/utils/axios/index.tsx
+++ b/utils/axios/index.tsx
@@ -47,7 +47,8 @@ function AxiosInterceptor({ children }: PropsWithChildren) {
   useEffect(() => {
     const requestIntercept = client.interceptors.request.use(
       (config: AxiosRequestConfig) => {
-        const { accessToken, refreshToken } = getTokens();
+        const { accessToken } = getTokens();
+
         if (config.headers && !config.headers['Authorization']) {
           config.headers['Authorization'] = `Bearer ${accessToken}`;
 

--- a/utils/hooks/auth/index.ts
+++ b/utils/hooks/auth/index.ts
@@ -23,11 +23,10 @@ export const useKaKaoLogin = () => {
           },
           {
             onSuccess: ({ data }) => {
-              cookie.save('accessToken', data.accessToken, {});
-              cookie.save('refreshToken', data.refreshToken, {});
-
               if (data.isAlreadyUser) {
                 setUser(data);
+                cookie.save('accessToken', data.accessToken, {});
+                cookie.save('refreshToken', data.refreshToken, {});
               } else {
                 setCreatingUser(data);
                 router.replace('/profile');


### PR DESCRIPTION
### 회원가입 후 토큰이 저장 안되는 오류 수정

기존: 카카오 로그인 성공 > 쿠키에 토큰 저장
변경: 카카오 로그인 성공 > 기존 유저인 경우만 쿠키에 토큰 저장